### PR TITLE
Implement lock-free ingestion demo with FIX parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.20)
+project(fx_dropcopy_recon CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(MSVC)
+  add_compile_options(/W4 /permissive-)
+else()
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+include(GNUInstallDirs)
+
+add_library(fx_core
+    src/ingest/spsc_ring.hpp
+    src/ingest/fix_parser.cpp
+    src/core/exec_event.hpp
+    src/core/reconciler.cpp
+    src/util/rdtsc.hpp
+    src/util/log.hpp
+    src/util/soh.hpp
+    src/util/arena.hpp
+)
+
+target_include_directories(fx_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+add_executable(fx_ingest_demo src/api/main.cpp src/ingest/fix_parser.cpp src/core/reconciler.cpp)
+target_link_libraries(fx_ingest_demo PRIVATE fx_core)
+
+add_executable(unit_tests
+    tests/all_tests.cpp
+    tests/ring_tests.cpp
+    tests/fix_parser_tests.cpp
+    tests/test_main.hpp
+    src/ingest/fix_parser.cpp
+    src/core/reconciler.cpp
+)
+target_include_directories(unit_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+target_link_libraries(unit_tests PRIVATE fx_core)
+
+add_executable(benchmarks bench/bench_main.cpp src/ingest/fix_parser.cpp src/core/reconciler.cpp)
+target_link_libraries(benchmarks PRIVATE fx_core)
+
+enable_testing()
+add_test(NAME unit_tests COMMAND unit_tests)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,47 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20
+  },
+  "configurePresets": [
+    {
+      "name": "debug",
+      "hidden": false,
+      "generator": "Ninja",
+      "binaryDir": "build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release",
+      "hidden": false,
+      "generator": "Ninja",
+      "binaryDir": "build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    }
+  ]
+}

--- a/bench/bench_main.cpp
+++ b/bench/bench_main.cpp
@@ -1,0 +1,27 @@
+#include <chrono>
+#include <iostream>
+
+#include "ingest/spsc_ring.hpp"
+#include "ingest/fix_parser.hpp"
+#include "core/exec_event.hpp"
+#include "util/soh.hpp"
+
+int main() {
+    ingest::SpscRing<core::ExecEvent, 1u << 16> ring;
+    core::ExecEvent evt{};
+
+    const std::string msg = util::pipe_to_soh("8=FIX.4.4|35=8|150=2|39=2|17=EXEC1|11=CID1|37=OID1|31=1000000|32=100|14=100|52=1|60=1|");
+
+    constexpr std::size_t iterations = 100000;
+    auto start = std::chrono::steady_clock::now();
+    for (std::size_t i = 0; i < iterations; ++i) {
+        ingest::parse_exec_report(msg.data(), msg.size(), evt);
+        ring.try_push(evt);
+        ring.try_pop(evt);
+    }
+    auto end = std::chrono::steady_clock::now();
+    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+    std::cout << "Benchmark loop " << iterations << " iterations took " << ns << " ns (" << (ns / iterations)
+              << " ns/iter)\n";
+    return 0;
+}

--- a/src/api/main.cpp
+++ b/src/api/main.cpp
@@ -1,0 +1,89 @@
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "core/exec_event.hpp"
+#include "core/reconciler.hpp"
+#include "ingest/fix_parser.hpp"
+#include "ingest/spsc_ring.hpp"
+#include "util/log.hpp"
+#include "util/soh.hpp"
+
+// SPSC rings are fixed-size (power of two). On push failure the caller drops and counts the
+// message; no blocking or heap fallback in the hot path.
+using Ring = ingest::SpscRing<core::ExecEvent, 1u << 16>;
+
+struct ThreadStats {
+    std::size_t produced{0};
+    std::size_t parse_failures{0};
+    std::size_t drops{0};
+};
+
+std::string make_exec_report(std::size_t seq, int64_t price_micro, int64_t qty) {
+    std::string msg = "8=FIX.4.4|35=8|150=2|39=2|17=EXEC" + std::to_string(seq) +
+                      "|11=CID" + std::to_string(seq) +
+                      "|37=OID" + std::to_string(seq) +
+                      "|31=" + std::to_string(price_micro) +
+                      "|32=" + std::to_string(qty) +
+                      "|14=" + std::to_string(qty) +
+                      "|52=20240101000000000|60=20240101000000000|";
+    return util::pipe_to_soh(msg);
+}
+
+// Ingest threads never throw in the hot path; they simply count failures and return on stop.
+void ingest_thread(std::atomic<bool>& stop_flag, Ring& ring, ThreadStats& stats, core::Source src) {
+    std::size_t seq = 1;
+    core::ExecEvent evt{};
+    while (!stop_flag.load(std::memory_order_acquire)) {
+        const std::string msg = make_exec_report(seq, 1000000 + static_cast<int64_t>(seq), 100 + (seq % 10));
+        if (ingest::parse_exec_report(msg.data(), msg.size(), evt) != ingest::ParseResult::Ok) {
+            ++stats.parse_failures;
+        } else {
+            evt.source = src;
+            if (!ring.try_push(evt)) {
+                ++stats.drops;
+            } else {
+                ++stats.produced;
+            }
+        }
+        ++seq;
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+}
+
+int main() {
+    // Thread lifecycle: main sets up structures, launches ingest + reconciler threads, and on
+    // shutdown sets stop_flag then joins in deterministic order (ingest before reconciler).
+    std::atomic<bool> stop_flag{false};
+    Ring primary_ring;
+    Ring dropcopy_ring;
+
+    ThreadStats primary_stats;
+    ThreadStats dropcopy_stats;
+    core::ReconCounters counters;
+
+    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, counters);
+
+    std::thread primary([&] { ingest_thread(stop_flag, primary_ring, primary_stats, core::Source::Primary); });
+    std::thread dropcopy([&] { ingest_thread(stop_flag, dropcopy_ring, dropcopy_stats, core::Source::DropCopy); });
+    std::thread recon_thread([&] { recon.run(); });
+
+    std::cout << "Running demo for 2 seconds..." << std::endl;
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    stop_flag.store(true, std::memory_order_release);
+
+    primary.join();
+    dropcopy.join();
+    recon_thread.join();
+
+    std::cout << "Primary produced: " << primary_stats.produced << " drops: " << primary_stats.drops
+              << " parse_failures: " << primary_stats.parse_failures << "\n";
+    std::cout << "DropCopy produced: " << dropcopy_stats.produced << " drops: " << dropcopy_stats.drops
+              << " parse_failures: " << dropcopy_stats.parse_failures << "\n";
+    std::cout << "Reconciler consumed primary: " << counters.consumed_primary
+              << " dropcopy: " << counters.consumed_dropcopy << "\n";
+    return 0;
+}

--- a/src/core/exec_event.hpp
+++ b/src/core/exec_event.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include <array>
+#include <cstring>
+
+namespace core {
+
+enum class Source : uint8_t { Primary = 0, DropCopy = 1 };
+enum class ExecType : uint8_t { New, PartialFill, Fill, Cancel, Replace, Rejected, Unknown };
+enum class OrdStatus : uint8_t { New, PartiallyFilled, Filled, Canceled, Replaced, Rejected, Unknown };
+
+struct ExecEvent {
+    Source source{};
+    ExecType exec_type{ExecType::Unknown};
+    OrdStatus ord_status{OrdStatus::Unknown};
+    int64_t price_micro{0}; // price in micro-units
+    int64_t qty{0};
+    int64_t cum_qty{0};
+    uint64_t sending_time{0};
+    uint64_t transact_time{0};
+    uint64_t ingest_tsc{0};
+
+    static constexpr std::size_t id_capacity = 32;
+    char exec_id[id_capacity]{};
+    std::size_t exec_id_len{0};
+    char order_id[id_capacity]{};
+    std::size_t order_id_len{0};
+    char clord_id[id_capacity]{};
+    std::size_t clord_id_len{0};
+
+    void set_order_id(const char* data, std::size_t len) noexcept {
+        const auto l = len > id_capacity ? id_capacity : len;
+        std::memcpy(order_id, data, l);
+        order_id_len = l;
+    }
+    void set_clord_id(const char* data, std::size_t len) noexcept {
+        const auto l = len > id_capacity ? id_capacity : len;
+        std::memcpy(clord_id, data, l);
+        clord_id_len = l;
+    }
+    void set_exec_id(const char* data, std::size_t len) noexcept {
+        const auto l = len > id_capacity ? id_capacity : len;
+        std::memcpy(exec_id, data, l);
+        exec_id_len = l;
+    }
+};
+
+} // namespace core

--- a/src/core/reconciler.cpp
+++ b/src/core/reconciler.cpp
@@ -1,0 +1,40 @@
+#include "core/reconciler.hpp"
+
+#include <chrono>
+#include <thread>
+
+namespace core {
+
+Reconciler::Reconciler(std::atomic<bool>& stop_flag,
+                       ingest::SpscRing<core::ExecEvent, 1u << 16>& primary,
+                       ingest::SpscRing<core::ExecEvent, 1u << 16>& dropcopy,
+                       ReconCounters& counters) noexcept
+    : stop_flag_(stop_flag), primary_(primary), dropcopy_(dropcopy), counters_(counters) {}
+
+void Reconciler::run() {
+    ExecEvent evt{};
+    std::uint32_t backoff = 0;
+    while (!stop_flag_.load(std::memory_order_acquire)) {
+        bool consumed = false;
+        if (primary_.try_pop(evt)) {
+            ++counters_.consumed_primary;
+            consumed = true;
+        }
+        if (dropcopy_.try_pop(evt)) {
+            ++counters_.consumed_dropcopy;
+            consumed = true;
+        }
+        if (!consumed) {
+            if (backoff < 16) {
+                ++backoff;
+                std::this_thread::yield();
+            } else {
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            }
+        } else {
+            backoff = 0;
+        }
+    }
+}
+
+} // namespace core

--- a/src/core/reconciler.hpp
+++ b/src/core/reconciler.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <atomic>
+#include <thread>
+
+#include "ingest/spsc_ring.hpp"
+#include "core/exec_event.hpp"
+
+namespace core {
+
+struct ReconCounters {
+    std::size_t consumed_primary{0};
+    std::size_t consumed_dropcopy{0};
+    std::size_t parse_failures{0};
+    std::size_t ring_drops{0};
+};
+
+class Reconciler {
+public:
+    Reconciler(std::atomic<bool>& stop_flag,
+               ingest::SpscRing<core::ExecEvent, 1u << 16>& primary,
+               ingest::SpscRing<core::ExecEvent, 1u << 16>& dropcopy,
+               ReconCounters& counters) noexcept;
+
+    void run();
+
+private:
+    std::atomic<bool>& stop_flag_;
+    ingest::SpscRing<core::ExecEvent, 1u << 16>& primary_;
+    ingest::SpscRing<core::ExecEvent, 1u << 16>& dropcopy_;
+    ReconCounters& counters_;
+};
+
+} // namespace core

--- a/src/ingest/fix_parser.cpp
+++ b/src/ingest/fix_parser.cpp
@@ -1,0 +1,161 @@
+#include "ingest/fix_parser.hpp"
+
+#include <charconv>
+#include <cstring>
+
+#include "util/rdtsc.hpp"
+
+namespace ingest {
+namespace {
+
+constexpr char soh = '\x01';
+
+inline bool parse_int64(const char* begin, const char* end, int64_t& out) noexcept {
+    auto res = std::from_chars(begin, end, out);
+    return res.ec == std::errc{} && res.ptr == end;
+}
+
+inline bool parse_uint64(const char* begin, const char* end, uint64_t& out) noexcept {
+    auto res = std::from_chars(begin, end, out);
+    return res.ec == std::errc{} && res.ptr == end;
+}
+
+inline void assign_id(const char* begin, const char* end, char* dest, std::size_t& len) noexcept {
+    const auto l = static_cast<std::size_t>(end - begin);
+    const auto to_copy = l > core::ExecEvent::id_capacity ? core::ExecEvent::id_capacity : l;
+    std::memcpy(dest, begin, to_copy);
+    len = to_copy;
+}
+
+inline core::ExecType map_exec_type(char c) noexcept {
+    switch (c) {
+    case '0': return core::ExecType::New;
+    case '1': return core::ExecType::PartialFill;
+    case '2': return core::ExecType::Fill;
+    case '4': return core::ExecType::Cancel;
+    case '5': return core::ExecType::Replace;
+    case '8': return core::ExecType::Rejected;
+    default: return core::ExecType::Unknown;
+    }
+}
+
+inline core::OrdStatus map_ord_status(char c) noexcept {
+    switch (c) {
+    case '0': return core::OrdStatus::New;
+    case '1': return core::OrdStatus::PartiallyFilled;
+    case '2': return core::OrdStatus::Filled;
+    case '4': return core::OrdStatus::Canceled;
+    case '5': return core::OrdStatus::Replaced;
+    case '8': return core::OrdStatus::Rejected;
+    default: return core::OrdStatus::Unknown;
+    }
+}
+
+} // namespace
+
+ParseResult parse_exec_report(const char* data, std::size_t len, core::ExecEvent& out) noexcept {
+    bool has_exec_type = false;
+    bool has_ord_status = false;
+    bool has_price = false;
+    bool has_qty = false;
+    bool has_exec_id = false;
+    bool has_time = false;
+
+    const char* ptr = data;
+    const char* end = data + len;
+
+    while (ptr < end) {
+        const char* tag_start = ptr;
+        while (ptr < end && *ptr != '=') ++ptr;
+        if (ptr >= end) break;
+        int64_t tag = 0;
+        if (!parse_int64(tag_start, ptr, tag)) return ParseResult::Invalid;
+        ++ptr; // skip '='
+        const char* val_start = ptr;
+        while (ptr < end && *ptr != soh) ++ptr;
+        const char* val_end = ptr;
+        if (ptr < end) ++ptr; // skip separator
+
+        switch (tag) {
+        case 35: { // MsgType
+            if (val_start == val_end) return ParseResult::Invalid;
+            // Only accept ExecReport (8)
+            if (*val_start != '8') return ParseResult::Invalid;
+            break;
+        }
+        case 150: { // ExecType
+            if (val_start == val_end) return ParseResult::Invalid;
+            out.exec_type = map_exec_type(*val_start);
+            has_exec_type = true;
+            break;
+        }
+        case 39: { // OrdStatus
+            if (val_start == val_end) return ParseResult::Invalid;
+            out.ord_status = map_ord_status(*val_start);
+            has_ord_status = true;
+            break;
+        }
+        case 31: { // LastPx -> using as price
+            int64_t price = 0;
+            if (!parse_int64(val_start, val_end, price)) return ParseResult::Invalid;
+            out.price_micro = price;
+            has_price = true;
+            break;
+        }
+        case 32: { // LastQty -> qty
+            int64_t qty = 0;
+            if (!parse_int64(val_start, val_end, qty)) return ParseResult::Invalid;
+            out.qty = qty;
+            has_qty = true;
+            break;
+        }
+        case 14: { // CumQty
+            int64_t cum = 0;
+            if (!parse_int64(val_start, val_end, cum)) return ParseResult::Invalid;
+            out.cum_qty = cum;
+            break;
+        }
+        case 17: { // ExecID
+            assign_id(val_start, val_end, out.exec_id, out.exec_id_len);
+            has_exec_id = true;
+            break;
+        }
+        case 11: { // ClOrdID
+            assign_id(val_start, val_end, out.clord_id, out.clord_id_len);
+            break;
+        }
+        case 37: { // OrderID
+            assign_id(val_start, val_end, out.order_id, out.order_id_len);
+            break;
+        }
+        case 52: { // SendingTime
+            uint64_t ts = 0;
+            if (!parse_uint64(val_start, val_end, ts)) return ParseResult::Invalid;
+            out.sending_time = ts;
+            has_time = true;
+            break;
+        }
+        case 60: { // TransactTime
+            uint64_t ts = 0;
+            if (!parse_uint64(val_start, val_end, ts)) return ParseResult::Invalid;
+            out.transact_time = ts;
+            has_time = true;
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+    out.ingest_tsc = util::rdtsc();
+
+    if (out.order_id_len == 0 && out.clord_id_len == 0) {
+        return ParseResult::MissingField;
+    }
+    if (!has_exec_type || !has_ord_status || !has_price || !has_qty || !has_exec_id || !has_time) {
+        return ParseResult::MissingField;
+    }
+    return ParseResult::Ok;
+}
+
+} // namespace ingest

--- a/src/ingest/fix_parser.hpp
+++ b/src/ingest/fix_parser.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "core/exec_event.hpp"
+
+namespace ingest {
+
+enum class ParseResult : uint8_t { Ok, MissingField, Invalid };
+
+struct ParseStats {
+    std::size_t parsed{0};
+    std::size_t failed{0};
+};
+
+ParseResult parse_exec_report(const char* data, std::size_t len, core::ExecEvent& out) noexcept;
+
+} // namespace ingest

--- a/src/ingest/spsc_ring.hpp
+++ b/src/ingest/spsc_ring.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <type_traits>
+
+namespace ingest {
+
+// Single-producer/single-consumer ring buffer with cache-line separated indices.
+// Producer uses relaxed load + release store; consumer uses relaxed load + acquire load and
+// release store to publish consumption. Capacity must be a power of two.
+template <typename T, std::size_t CapacityPowerOf2>
+class alignas(64) SpscRing {
+    static_assert((CapacityPowerOf2 & (CapacityPowerOf2 - 1)) == 0,
+                  "Capacity must be power of two");
+
+public:
+    SpscRing() : head_(0), tail_(0) {}
+
+    bool try_push(const T& v) noexcept {
+        const auto head = head_.load(std::memory_order_relaxed);
+        const auto next_head = increment(head);
+        if (next_head == tail_.load(std::memory_order_acquire)) {
+            return false; // full
+        }
+        buffer_[head] = v;
+        head_.store(next_head, std::memory_order_release);
+        return true;
+    }
+
+    bool try_pop(T& out) noexcept {
+        const auto tail = tail_.load(std::memory_order_relaxed);
+        if (tail == head_.load(std::memory_order_acquire)) {
+            return false; // empty
+        }
+        out = buffer_[tail];
+        tail_.store(increment(tail), std::memory_order_release);
+        return true;
+    }
+
+    std::size_t size_approx() const noexcept {
+        const auto head = head_.load(std::memory_order_acquire);
+        const auto tail = tail_.load(std::memory_order_acquire);
+        return head >= tail ? head - tail : CapacityPowerOf2 - (tail - head);
+    }
+
+    static constexpr std::size_t capacity() noexcept { return CapacityPowerOf2; }
+
+private:
+    static constexpr std::size_t increment(std::size_t idx) noexcept {
+        return (idx + 1) & (CapacityPowerOf2 - 1);
+    }
+
+    alignas(64) std::atomic<std::size_t> head_;
+    alignas(64) std::atomic<std::size_t> tail_;
+    T buffer_[CapacityPowerOf2];
+};
+
+} // namespace ingest

--- a/src/persist/README.md
+++ b/src/persist/README.md
@@ -1,0 +1,1 @@
+Persistence layer placeholders. Implementation will be added in future milestones.

--- a/src/util/arena.hpp
+++ b/src/util/arena.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+
+namespace util {
+// Placeholder arena allocator stub for future use.
+class Arena {
+public:
+    Arena() = default;
+    void* allocate(std::size_t size, std::size_t alignment = alignof(std::max_align_t)) {
+        (void)size; (void)alignment;
+        return nullptr; // stub
+    }
+    void reset() {}
+};
+} // namespace util

--- a/src/util/log.hpp
+++ b/src/util/log.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdarg>
+#include <mutex>
+
+namespace util {
+
+enum class LogLevel { Trace, Debug, Info, Warn, Error, Fatal };
+
+inline const char* level_name(LogLevel lvl) noexcept {
+    switch (lvl) {
+    case LogLevel::Trace: return "TRACE";
+    case LogLevel::Debug: return "DEBUG";
+    case LogLevel::Info: return "INFO";
+    case LogLevel::Warn: return "WARN";
+    case LogLevel::Error: return "ERROR";
+    case LogLevel::Fatal: return "FATAL";
+    }
+    return "UNKNOWN";
+}
+
+inline void log(LogLevel lvl, const char* fmt, ...) {
+    static std::mutex mtx;
+    std::lock_guard<std::mutex> lock(mtx);
+    std::fprintf(stderr, "%s: ", level_name(lvl));
+    va_list args;
+    va_start(args, fmt);
+    std::vfprintf(stderr, fmt, args);
+    va_end(args);
+    std::fprintf(stderr, "\n");
+}
+
+} // namespace util

--- a/src/util/rdtsc.hpp
+++ b/src/util/rdtsc.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cstdint>
+#include <chrono>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+namespace util {
+
+inline uint64_t rdtsc(bool fence = false) noexcept {
+#if defined(__i386__) || defined(__x86_64__)
+    if (fence) {
+#if defined(_MSC_VER)
+        _mm_lfence();
+#elif defined(__GNUC__)
+        __asm__ __volatile__("lfence" ::: "memory");
+#endif
+    }
+    unsigned int lo = 0, hi = 0;
+#if defined(_MSC_VER)
+    return __rdtsc();
+#elif defined(__GNUC__)
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return (static_cast<uint64_t>(hi) << 32) | lo;
+#else
+    return 0;
+#endif
+#else
+    (void)fence;
+    return static_cast<uint64_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+#endif
+}
+
+} // namespace util

--- a/src/util/soh.hpp
+++ b/src/util/soh.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+namespace util {
+inline std::string pipe_to_soh(const std::string& msg) {
+    std::string out = msg;
+    for (char& c : out) {
+        if (c == '|') c = '\x01';
+    }
+    return out;
+}
+} // namespace util

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -1,0 +1,11 @@
+#include "test_main.hpp"
+
+namespace ring_tests { void add_tests(std::vector<TestCase>& tests); }
+namespace fix_parser_tests { void add_tests(std::vector<TestCase>& tests); }
+
+int main() {
+    std::vector<TestCase> tests;
+    ring_tests::add_tests(tests);
+    fix_parser_tests::add_tests(tests);
+    return run_tests(tests);
+}

--- a/tests/fix_parser_tests.cpp
+++ b/tests/fix_parser_tests.cpp
@@ -1,0 +1,25 @@
+#include "test_main.hpp"
+#include "ingest/fix_parser.hpp"
+#include "util/soh.hpp"
+
+namespace fix_parser_tests {
+
+bool test_parse_exec_report_ok() {
+    const std::string msg = util::pipe_to_soh("8=FIX.4.4|35=8|150=2|39=2|17=E1|11=C1|37=O1|31=1000000|32=200|14=200|52=1|60=2|");
+    core::ExecEvent evt{};
+    return ingest::parse_exec_report(msg.data(), msg.size(), evt) == ingest::ParseResult::Ok &&
+           evt.price_micro == 1000000 && evt.qty == 200 && evt.cum_qty == 200 && evt.exec_id_len == 2;
+}
+
+bool test_missing_required_field() {
+    const std::string msg = util::pipe_to_soh("8=FIX.4.4|35=8|150=2|39=2|17=E1|31=1000000|32=200|14=200|52=1|60=2|");
+    core::ExecEvent evt{};
+    return ingest::parse_exec_report(msg.data(), msg.size(), evt) == ingest::ParseResult::MissingField;
+}
+
+void add_tests(std::vector<TestCase>& tests) {
+    tests.push_back({"parse_exec_report_ok", test_parse_exec_report_ok});
+    tests.push_back({"missing_required_field", test_missing_required_field});
+}
+
+} // namespace fix_parser_tests

--- a/tests/ring_tests.cpp
+++ b/tests/ring_tests.cpp
@@ -1,0 +1,42 @@
+#include "test_main.hpp"
+#include "ingest/spsc_ring.hpp"
+#include "core/exec_event.hpp"
+
+using Ring = ingest::SpscRing<core::ExecEvent, 8>;
+
+namespace ring_tests {
+
+bool test_push_pop_order() {
+    Ring ring;
+    core::ExecEvent a{}; a.qty = 1;
+    core::ExecEvent b{}; b.qty = 2;
+    core::ExecEvent out{};
+    bool ok = ring.try_push(a);
+    ok = ok && ring.try_push(b);
+    ok = ok && ring.try_pop(out) && out.qty == 1;
+    ok = ok && ring.try_pop(out) && out.qty == 2;
+    return ok;
+}
+
+bool test_full_empty_behavior() {
+    Ring ring;
+    core::ExecEvent evt{};
+    bool ok = true;
+    for (int i = 0; i < 7; ++i) {
+        ok = ok && ring.try_push(evt);
+    }
+    // ring is full now; next push should fail
+    ok = ok && !ring.try_push(evt);
+    for (int i = 0; i < 7; ++i) {
+        ok = ok && ring.try_pop(evt);
+    }
+    ok = ok && !ring.try_pop(evt);
+    return ok;
+}
+
+void add_tests(std::vector<TestCase>& tests) {
+    tests.push_back({"push_pop_order", test_push_pop_order});
+    tests.push_back({"full_empty_behavior", test_full_empty_behavior});
+}
+
+} // namespace ring_tests

--- a/tests/test_main.hpp
+++ b/tests/test_main.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+struct TestCase {
+    std::string name;
+    bool (*fn)();
+};
+
+inline int run_tests(const std::vector<TestCase>& tests) {
+    int failures = 0;
+    for (const auto& t : tests) {
+        const bool ok = t.fn();
+        std::cout << (ok ? "[PASS] " : "[FAIL] ") << t.name << "\n";
+        if (!ok) ++failures;
+    }
+    std::cout << "Summary: " << (tests.size() - failures) << "/" << tests.size() << " passed\n";
+    return failures;
+}


### PR DESCRIPTION
## Summary
- add cache-aligned SPSC ring buffer and minimal ExecEvent model for ingest
- implement FIX ExecReport parser with TSC timestamping and CLI demo threads with drop policy
- provide unit tests, benchmark skeleton, and CMake presets for builds

## Testing
- cmake --build --preset debug
- ctest --preset debug


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3d969f388328b83753a1a5f7cea9)