### PR TITLE
Add lifecycle and divergence helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ add_library(fx_core
     src/ingest/aeron_client_view.hpp
     src/core/exec_event.hpp
     src/core/wire_exec_event.hpp
+    src/core/order_lifecycle.hpp
+    src/core/divergence.hpp
     src/core/order_state.hpp
     src/core/order_state_store.cpp
     src/core/reconciler.cpp
@@ -178,6 +180,8 @@ add_executable(unit_tests
     tests/aeron_subscriber_tests.cpp
     tests/arena_tests.cpp
     tests/order_state_tests.cpp
+    tests/order_lifecycle_tests.cpp
+    tests/divergence_tests.cpp
     tests/order_state_store_tests.cpp
     tests/test_main.hpp
     src/ingest/aeron_subscriber.cpp

--- a/src/core/divergence.hpp
+++ b/src/core/divergence.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+
+#include "core/order_state.hpp"
+
+namespace core {
+
+enum class DivergenceType : std::uint8_t {
+    MissingFill,     // DropCopy filled/partial, internal not reflecting it
+    PhantomOrder,    // DropCopy has order, internal has no record
+    StateMismatch,   // OrdStatus mismatch (e.g. Filled vs Working)
+    QuantityMismatch,// CumQty/AvgPx mismatch beyond tolerance
+    TimingAnomaly    // DropCopy significantly earlier than internal
+};
+
+struct Divergence {
+    OrderKey key{0};
+    DivergenceType type{DivergenceType::StateMismatch};
+    OrdStatus internal_status{OrdStatus::Unknown};
+    OrdStatus dropcopy_status{OrdStatus::Unknown};
+    std::int64_t internal_cum_qty{0};
+    std::int64_t dropcopy_cum_qty{0};
+    std::int64_t internal_avg_px{0};
+    std::int64_t dropcopy_avg_px{0};
+    std::uint64_t internal_ts{0};
+    std::uint64_t dropcopy_ts{0};
+};
+
+inline void fill_divergence_snapshot(const OrderState& state,
+                                     DivergenceType type,
+                                     Divergence& out) noexcept {
+    out.key = state.key;
+    out.type = type;
+    out.internal_status = state.internal_status;
+    out.dropcopy_status = state.dropcopy_status;
+    out.internal_cum_qty = state.internal_cum_qty;
+    out.dropcopy_cum_qty = state.dropcopy_cum_qty;
+    out.internal_avg_px = state.internal_avg_px;
+    out.dropcopy_avg_px = state.dropcopy_avg_px;
+    out.internal_ts = state.last_internal_ts;
+    out.dropcopy_ts = state.last_dropcopy_ts;
+}
+
+// Priority order: PhantomOrder > MissingFill > StateMismatch > QuantityMismatch > TimingAnomaly.
+inline bool classify_divergence(const OrderState& state,
+                                Divergence& out,
+                                std::int64_t qty_tolerance = 0,
+                                std::int64_t px_tolerance = 0,
+                                std::uint64_t timing_slack = 0) noexcept {
+    using OS = OrdStatus;
+
+    if (!state.seen_dropcopy) {
+        return false;
+    }
+
+    if (!state.seen_internal) {
+        fill_divergence_snapshot(state, DivergenceType::PhantomOrder, out);
+        return true;
+    }
+
+    const bool dropcopy_is_fill = state.dropcopy_status == OS::Filled ||
+                                  state.dropcopy_status == OS::PartiallyFilled;
+    const bool internal_pre_filled = state.internal_status == OS::New ||
+                                     state.internal_status == OS::PendingNew ||
+                                     state.internal_status == OS::Working;
+
+    if (dropcopy_is_fill && internal_pre_filled) {
+        fill_divergence_snapshot(state, DivergenceType::MissingFill, out);
+        return true;
+    }
+
+    if (state.dropcopy_status != state.internal_status) {
+        fill_divergence_snapshot(state, DivergenceType::StateMismatch, out);
+        return true;
+    }
+
+    const auto qty_diff = std::llabs(state.dropcopy_cum_qty - state.internal_cum_qty);
+    const auto px_diff = std::llabs(state.dropcopy_avg_px - state.internal_avg_px);
+    if (qty_diff > qty_tolerance || px_diff > px_tolerance) {
+        fill_divergence_snapshot(state, DivergenceType::QuantityMismatch, out);
+        return true;
+    }
+
+    if (state.last_dropcopy_ts + timing_slack < state.last_internal_ts) {
+        fill_divergence_snapshot(state, DivergenceType::TimingAnomaly, out);
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace core
+

--- a/src/core/exec_event.hpp
+++ b/src/core/exec_event.hpp
@@ -11,7 +11,18 @@ namespace core {
 
 enum class Source : uint8_t { Primary = 0, DropCopy = 1 };
 enum class ExecType : uint8_t { New, PartialFill, Fill, Cancel, Replace, Rejected, Unknown };
-enum class OrdStatus : uint8_t { New, PartiallyFilled, Filled, Canceled, Replaced, Rejected, Unknown };
+enum class OrdStatus : uint8_t {
+    New = 0,
+    PartiallyFilled = 1,
+    Filled = 2,
+    Canceled = 3,
+    Replaced = 4,
+    Rejected = 5,
+    Unknown = 6,
+    PendingNew = 7,
+    Working = 8,
+    CancelPending = 9
+};
 
 struct ExecEvent {
     Source source{};

--- a/src/core/order_lifecycle.hpp
+++ b/src/core/order_lifecycle.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "core/exec_event.hpp"
+
+namespace core {
+
+inline constexpr bool is_terminal_status(OrdStatus s) noexcept {
+    switch (s) {
+    case OrdStatus::Filled:
+    case OrdStatus::Canceled:
+    case OrdStatus::Rejected:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// Validate whether a transition between two OrdStatus values is acceptable for an
+// exchange-grade order lifecycle. Unknown permits any first observation.
+inline bool is_valid_transition(OrdStatus current, OrdStatus next) noexcept {
+    using OS = OrdStatus;
+
+    if (current == OS::Unknown) {
+        return true; // First observation wins.
+    }
+
+    if (current == next) {
+        // Idempotent repeats are acceptable (e.g., duplicate drop-copy messages).
+        return true;
+    }
+
+    if (is_terminal_status(current)) {
+        // Terminal states cannot transition back to active lifecycle states.
+        return false;
+    }
+
+    switch (current) {
+    case OS::New:
+    case OS::PendingNew:
+        return next == OS::Working || next == OS::PartiallyFilled || next == OS::Filled ||
+               next == OS::CancelPending || next == OS::Rejected;
+    case OS::Working:
+        return next == OS::PartiallyFilled || next == OS::Filled || next == OS::CancelPending ||
+               next == OS::Rejected;
+    case OS::PartiallyFilled:
+        return next == OS::PartiallyFilled || next == OS::Filled || next == OS::CancelPending;
+    case OS::CancelPending:
+        return next == OS::Canceled || next == OS::Rejected || next == OS::PartiallyFilled ||
+               next == OS::Filled;
+    case OS::Replaced:
+        return next == OS::Working || next == OS::PartiallyFilled || next == OS::Filled ||
+               next == OS::CancelPending || next == OS::Rejected;
+    default:
+        return false;
+    }
+}
+
+// Apply a new status to the current lifecycle, returning whether the change was accepted.
+inline bool apply_status_transition(OrdStatus& current, OrdStatus next) noexcept {
+    if (!is_valid_transition(current, next)) {
+        return false;
+    }
+    current = next;
+    return true;
+}
+
+} // namespace core
+

--- a/src/ingest/fix_parser.cpp
+++ b/src/ingest/fix_parser.cpp
@@ -42,6 +42,8 @@ inline core::ExecType map_exec_type(char c) noexcept {
 inline core::OrdStatus map_ord_status(char c) noexcept {
     switch (c) {
     case '0': return core::OrdStatus::New;
+    case 'A': return core::OrdStatus::PendingNew;
+    case '6': return core::OrdStatus::CancelPending;
     case '1': return core::OrdStatus::PartiallyFilled;
     case '2': return core::OrdStatus::Filled;
     case '4': return core::OrdStatus::Canceled;

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -6,6 +6,8 @@ namespace wire_exec_tests { void add_tests(std::vector<TestCase>& tests); }
 namespace aeron_subscriber_tests { void add_tests(std::vector<TestCase>& tests); }
 namespace arena_tests { void add_tests(std::vector<TestCase>& tests); }
 namespace order_state_tests { void add_tests(std::vector<TestCase>& tests); }
+namespace order_lifecycle_tests { void add_tests(std::vector<TestCase>& tests); }
+namespace divergence_tests { void add_tests(std::vector<TestCase>& tests); }
 namespace order_state_store_tests { void add_tests(std::vector<TestCase>& tests); }
 
 int main() {
@@ -16,6 +18,8 @@ int main() {
     aeron_subscriber_tests::add_tests(tests);
     arena_tests::add_tests(tests);
     order_state_tests::add_tests(tests);
+    order_lifecycle_tests::add_tests(tests);
+    divergence_tests::add_tests(tests);
     order_state_store_tests::add_tests(tests);
     return run_tests(tests);
 }

--- a/tests/divergence_tests.cpp
+++ b/tests/divergence_tests.cpp
@@ -1,0 +1,104 @@
+#include "test_main.hpp"
+
+#include "core/divergence.hpp"
+
+namespace divergence_tests {
+
+bool test_phantom_order_detection() {
+    core::OrderState state{};
+    state.key = 1;
+    state.seen_dropcopy = true;
+    state.dropcopy_status = core::OrdStatus::New;
+    state.last_dropcopy_ts = 100;
+
+    core::Divergence div{};
+    if (!core::classify_divergence(state, div)) return false;
+    return div.type == core::DivergenceType::PhantomOrder && div.key == state.key;
+}
+
+bool test_missing_fill_detection() {
+    core::OrderState state{};
+    state.key = 2;
+    state.seen_internal = true;
+    state.seen_dropcopy = true;
+    state.internal_status = core::OrdStatus::Working;
+    state.internal_cum_qty = 10;
+    state.internal_avg_px = 100;
+    state.last_internal_ts = 200;
+    state.dropcopy_status = core::OrdStatus::Filled;
+    state.dropcopy_cum_qty = 20;
+    state.dropcopy_avg_px = 105;
+    state.last_dropcopy_ts = 150;
+
+    core::Divergence div{};
+    if (!core::classify_divergence(state, div)) return false;
+    return div.type == core::DivergenceType::MissingFill &&
+           div.internal_status == core::OrdStatus::Working &&
+           div.dropcopy_status == core::OrdStatus::Filled;
+}
+
+bool test_state_mismatch_detection() {
+    core::OrderState state{};
+    state.key = 3;
+    state.seen_internal = true;
+    state.seen_dropcopy = true;
+    state.internal_status = core::OrdStatus::PartiallyFilled;
+    state.dropcopy_status = core::OrdStatus::Filled;
+    state.internal_cum_qty = 15;
+    state.dropcopy_cum_qty = 15;
+
+    core::Divergence div{};
+    if (!core::classify_divergence(state, div)) return false;
+    return div.type == core::DivergenceType::StateMismatch &&
+           div.internal_status == core::OrdStatus::PartiallyFilled &&
+           div.dropcopy_status == core::OrdStatus::Filled;
+}
+
+bool test_quantity_mismatch_detection() {
+    core::OrderState state{};
+    state.key = 4;
+    state.seen_internal = true;
+    state.seen_dropcopy = true;
+    state.internal_status = core::OrdStatus::Filled;
+    state.dropcopy_status = core::OrdStatus::Filled;
+    state.internal_cum_qty = 10;
+    state.dropcopy_cum_qty = 20;
+    state.internal_avg_px = 100;
+    state.dropcopy_avg_px = 100;
+
+    core::Divergence div{};
+    if (!core::classify_divergence(state, div, 5)) return false;
+    return div.type == core::DivergenceType::QuantityMismatch &&
+           div.dropcopy_cum_qty == 20 &&
+           div.internal_cum_qty == 10;
+}
+
+bool test_timing_anomaly_detection() {
+    core::OrderState state{};
+    state.key = 5;
+    state.seen_internal = true;
+    state.seen_dropcopy = true;
+    state.internal_status = core::OrdStatus::PartiallyFilled;
+    state.dropcopy_status = core::OrdStatus::PartiallyFilled;
+    state.internal_cum_qty = 10;
+    state.dropcopy_cum_qty = 10;
+    state.last_dropcopy_ts = 100;
+    state.last_internal_ts = 200;
+
+    core::Divergence div{};
+    if (!core::classify_divergence(state, div, 0, 0, 50)) return false;
+    return div.type == core::DivergenceType::TimingAnomaly &&
+           div.dropcopy_ts == state.last_dropcopy_ts &&
+           div.internal_ts == state.last_internal_ts;
+}
+
+void add_tests(std::vector<TestCase>& tests) {
+    tests.push_back({"divergence_phantom_order_detection", test_phantom_order_detection});
+    tests.push_back({"divergence_missing_fill_detection", test_missing_fill_detection});
+    tests.push_back({"divergence_state_mismatch_detection", test_state_mismatch_detection});
+    tests.push_back({"divergence_quantity_mismatch_detection", test_quantity_mismatch_detection});
+    tests.push_back({"divergence_timing_anomaly_detection", test_timing_anomaly_detection});
+}
+
+} // namespace divergence_tests
+

--- a/tests/order_lifecycle_tests.cpp
+++ b/tests/order_lifecycle_tests.cpp
@@ -1,0 +1,44 @@
+#include "test_main.hpp"
+#include "core/order_lifecycle.hpp"
+
+namespace order_lifecycle_tests {
+
+bool test_valid_transitions_apply() {
+    core::OrdStatus status = core::OrdStatus::New;
+    if (!core::apply_status_transition(status, core::OrdStatus::Working)) return false;
+    if (status != core::OrdStatus::Working) return false;
+    if (!core::apply_status_transition(status, core::OrdStatus::PartiallyFilled)) return false;
+    if (status != core::OrdStatus::PartiallyFilled) return false;
+    if (!core::apply_status_transition(status, core::OrdStatus::Filled)) return false;
+    return status == core::OrdStatus::Filled;
+}
+
+bool test_invalid_transitions_rejected() {
+    core::OrdStatus status = core::OrdStatus::Filled;
+    if (core::apply_status_transition(status, core::OrdStatus::New)) return false;
+    if (status != core::OrdStatus::Filled) return false;
+
+    status = core::OrdStatus::Canceled;
+    if (core::apply_status_transition(status, core::OrdStatus::Working)) return false;
+    if (status != core::OrdStatus::Canceled) return false;
+
+    status = core::OrdStatus::PartiallyFilled;
+    if (core::apply_status_transition(status, core::OrdStatus::Working)) return false;
+    return status == core::OrdStatus::PartiallyFilled;
+}
+
+bool test_unknown_accepts_first_status() {
+    core::OrdStatus status = core::OrdStatus::Unknown;
+    if (!core::is_valid_transition(status, core::OrdStatus::New)) return false;
+    if (!core::apply_status_transition(status, core::OrdStatus::New)) return false;
+    return status == core::OrdStatus::New;
+}
+
+void add_tests(std::vector<TestCase>& tests) {
+    tests.push_back({"order_lifecycle_valid_transitions_apply", test_valid_transitions_apply});
+    tests.push_back({"order_lifecycle_invalid_transitions_rejected", test_invalid_transitions_rejected});
+    tests.push_back({"order_lifecycle_unknown_accepts_first_status", test_unknown_accepts_first_status});
+}
+
+} // namespace order_lifecycle_tests
+

--- a/tests/order_state_tests.cpp
+++ b/tests/order_state_tests.cpp
@@ -27,6 +27,8 @@ bool test_create_order_state_initialization() {
     bool ok = state->key == expected_key;
     ok = ok && state->internal_cum_qty == 0 && state->internal_avg_px == 0;
     ok = ok && state->dropcopy_cum_qty == 0 && state->dropcopy_avg_px == 0;
+    ok = ok && state->internal_status == core::OrdStatus::Unknown;
+    ok = ok && state->dropcopy_status == core::OrdStatus::Unknown;
     ok = ok && state->last_internal_exec_id_len == 0 && state->last_dropcopy_exec_id_len == 0;
     ok = ok && !state->seen_internal && !state->seen_dropcopy;
     ok = ok && !state->has_divergence && !state->has_gap;


### PR DESCRIPTION
## Summary
- add lifecycle transition validation helpers and extend order state tracking for drop-copy status
- implement divergence classification utilities plus exec application helpers for internal and drop-copy events
- expand the unit test suite to cover lifecycle transitions and divergence scenarios

## Testing
- AERON_ROOT=/workspace/aeron_stub cmake --preset debug
- cmake --build --preset debug
- ./build/debug/unit_tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946aa59868483288fbacea356b29aaf)