### PR TITLE
Add sequence gap tracking and detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(fx_core
     src/ingest/aeron_client_view.hpp
     src/core/exec_event.hpp
     src/core/wire_exec_event.hpp
+    src/core/sequence_tracker.hpp
     src/core/order_lifecycle.hpp
     src/core/divergence.hpp
     src/core/order_state.hpp
@@ -184,6 +185,8 @@ add_executable(unit_tests
     tests/divergence_tests.cpp
     tests/order_state_store_tests.cpp
     tests/reconciler_logic_tests.cpp
+    tests/sequence_tracker_tests.cpp
+    tests/reconciler_sequence_tests.cpp
     tests/test_main.hpp
     src/ingest/aeron_subscriber.cpp
     src/ingest/fix_parser.cpp

--- a/src/api/aeron_publisher.cpp
+++ b/src/api/aeron_publisher.cpp
@@ -24,6 +24,8 @@ core::WireExecEvent make_wire_exec(std::size_t seq) {
     core::WireExecEvent evt{};
     evt.exec_type = 2; // Fill
     evt.ord_status = 2; // Filled
+    evt.seq_num = static_cast<std::uint64_t>(seq);
+    evt.session_id = 0;
     evt.price_micro = 1000000 + static_cast<std::int64_t>(seq);
     evt.qty = 100 + static_cast<std::int64_t>(seq);
     evt.cum_qty = evt.qty;

--- a/src/api/demo_main.cpp
+++ b/src/api/demo_main.cpp
@@ -45,6 +45,7 @@ void ingest_thread(std::atomic<bool>& stop_flag, Ring& ring, ThreadStats& stats,
             ++stats.parse_failures;
         } else {
             evt.source = src;
+            evt.seq_num = seq;
             if (!ring.try_push(evt)) {
                 ++stats.drops;
             } else {
@@ -63,6 +64,7 @@ int main() {
     Ring primary_ring;
     Ring dropcopy_ring;
     core::DivergenceRing divergence_ring;
+    core::SequenceGapRing seq_gap_ring;
 
     ThreadStats primary_stats;
     ThreadStats dropcopy_stats;
@@ -71,7 +73,7 @@ int main() {
     constexpr std::size_t order_capacity_hint = 1u << 14;
     core::OrderStateStore store(arena, order_capacity_hint);
 
-    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, store, counters, divergence_ring);
+    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, store, counters, divergence_ring, seq_gap_ring);
 
     std::thread primary([&] { ingest_thread(stop_flag, primary_ring, primary_stats, core::Source::Primary); });
     std::thread dropcopy([&] { ingest_thread(stop_flag, dropcopy_ring, dropcopy_stats, core::Source::DropCopy); });

--- a/src/api/recond_main.cpp
+++ b/src/api/recond_main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char** argv) {
     ingest::Ring primary_ring;
     ingest::Ring dropcopy_ring;
     core::DivergenceRing divergence_ring;
+    core::SequenceGapRing seq_gap_ring;
 
     ingest::ThreadStats primary_stats;
     ingest::ThreadStats dropcopy_stats;
@@ -41,7 +42,7 @@ int main(int argc, char** argv) {
     aeron::Context context;
     auto client = aeron::Aeron::connect(context);
 
-    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, store, counters, divergence_ring);
+    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, store, counters, divergence_ring, seq_gap_ring);
 
     ingest::AeronSubscriber primary_sub(primary_channel, primary_stream, primary_ring, primary_stats,
                                         core::Source::Primary, client, stop_flag);

--- a/src/core/exec_event.hpp
+++ b/src/core/exec_event.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <array>
 #include <cstring>
+#include <type_traits>
 
 #include "core/wire_exec_event.hpp"
 
@@ -28,6 +29,8 @@ struct ExecEvent {
     Source source{};
     ExecType exec_type{ExecType::Unknown};
     OrdStatus ord_status{OrdStatus::Unknown};
+    std::uint64_t seq_num{0};     // session-level sequence number
+    std::uint16_t session_id{0};  // optional session/stream identifier
     int64_t price_micro{0}; // price in micro-units
     int64_t qty{0};
     int64_t cum_qty{0};
@@ -67,6 +70,8 @@ inline ExecEvent from_wire(const WireExecEvent& w, Source src, uint64_t ingest_t
     evt.source = src;
     evt.exec_type = static_cast<ExecType>(w.exec_type);
     evt.ord_status = static_cast<OrdStatus>(w.ord_status);
+    evt.seq_num = w.seq_num;
+    evt.session_id = w.session_id;
     evt.price_micro = w.price_micro;
     evt.qty = w.qty;
     evt.cum_qty = w.cum_qty;
@@ -91,5 +96,7 @@ inline ExecEvent from_wire(const WireExecEvent& w, Source src, uint64_t ingest_t
 
     return evt;
 }
+
+static_assert(std::is_trivially_copyable_v<ExecEvent>, "ExecEvent must remain trivially copyable");
 
 } // namespace core

--- a/src/core/sequence_tracker.hpp
+++ b/src/core/sequence_tracker.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cstdint>
+
+#include "core/exec_event.hpp"
+
+namespace core {
+
+enum class GapKind : std::uint8_t {
+    Gap,
+    Duplicate,
+    OutOfOrder
+};
+
+struct SequenceGapEvent {
+    Source source{};
+    std::uint16_t session_id{0};
+    std::uint64_t expected_seq{0};
+    std::uint64_t seen_seq{0};
+    GapKind kind{GapKind::Gap};
+    std::uint64_t detect_ts{0};
+};
+
+struct SequenceTracker {
+    std::uint64_t expected_seq{0};
+    std::uint64_t last_seen_seq{0};
+    bool initialized{false};
+    bool gap_open{false};
+    std::uint64_t gap_start_seq{0};
+};
+
+inline bool init_sequence_tracker(SequenceTracker& trk, std::uint64_t first_seq) noexcept {
+    if (trk.initialized) {
+        return false;
+    }
+    trk.initialized = true;
+    trk.last_seen_seq = first_seq;
+    trk.expected_seq = first_seq + 1;
+    trk.gap_open = false;
+    trk.gap_start_seq = 0;
+    return true;
+}
+
+inline bool track_sequence(SequenceTracker& trk,
+                           Source source,
+                           std::uint16_t session_id,
+                           std::uint64_t seq,
+                           std::uint64_t now_ts,
+                           SequenceGapEvent* out_event) noexcept {
+    if (!trk.initialized) {
+        init_sequence_tracker(trk, seq);
+        return false;
+    }
+
+    if (seq == trk.expected_seq) {
+        trk.last_seen_seq = seq;
+        trk.expected_seq = seq + 1;
+        return false;
+    }
+
+    if (seq > trk.expected_seq) {
+        const std::uint64_t expected_before = trk.expected_seq;
+        trk.gap_open = true;
+        trk.gap_start_seq = trk.expected_seq;
+        trk.last_seen_seq = seq;
+        trk.expected_seq = seq + 1;
+
+        if (out_event) {
+            out_event->source = source;
+            out_event->session_id = session_id;
+            out_event->expected_seq = expected_before;
+            out_event->seen_seq = seq;
+            out_event->kind = GapKind::Gap;
+            out_event->detect_ts = now_ts;
+        }
+        return true;
+    }
+
+    // seq < expected_seq
+    if (out_event) {
+        out_event->source = source;
+        out_event->session_id = session_id;
+        out_event->expected_seq = trk.expected_seq;
+        out_event->seen_seq = seq;
+        out_event->kind = (seq == trk.last_seen_seq) ? GapKind::Duplicate : GapKind::OutOfOrder;
+        out_event->detect_ts = now_ts;
+    }
+    return true;
+}
+
+} // namespace core

--- a/src/core/wire_exec_event.hpp
+++ b/src/core/wire_exec_event.hpp
@@ -15,6 +15,8 @@ struct WireExecEvent {
 
     std::uint8_t exec_type{0};
     std::uint8_t ord_status{0};
+    std::uint64_t seq_num{0};
+    std::uint16_t session_id{0};
     std::int64_t price_micro{0};
     std::int64_t qty{0};
     std::int64_t cum_qty{0};
@@ -33,6 +35,6 @@ struct WireExecEvent {
 #pragma pack(pop)
 
 static_assert(std::is_trivially_copyable_v<WireExecEvent>, "WireExecEvent must be trivial");
-static_assert(sizeof(WireExecEvent) == 141, "WireExecEvent layout is expected to be packed and fixed-size");
+static_assert(sizeof(WireExecEvent) == 151, "WireExecEvent layout is expected to be packed and fixed-size");
 
 } // namespace core

--- a/tests/aeron_subscriber_tests.cpp
+++ b/tests/aeron_subscriber_tests.cpp
@@ -66,6 +66,8 @@ core::WireExecEvent make_wire() {
     core::WireExecEvent wire{};
     wire.exec_type = 2;
     wire.ord_status = 2;
+    wire.seq_num = 1;
+    wire.session_id = 0;
     wire.price_micro = 1;
     wire.qty = 2;
     wire.cum_qty = 2;

--- a/tests/all_tests.cpp
+++ b/tests/all_tests.cpp
@@ -10,6 +10,8 @@ namespace order_lifecycle_tests { void add_tests(std::vector<TestCase>& tests); 
 namespace divergence_tests { void add_tests(std::vector<TestCase>& tests); }
 namespace order_state_store_tests { void add_tests(std::vector<TestCase>& tests); }
 namespace reconciler_logic_tests { void add_tests(std::vector<TestCase>& tests); }
+namespace sequence_tracker_tests { void add_tests(std::vector<TestCase>& tests); }
+namespace reconciler_sequence_tests { void add_tests(std::vector<TestCase>& tests); }
 
 int main() {
     std::vector<TestCase> tests;
@@ -23,5 +25,7 @@ int main() {
     divergence_tests::add_tests(tests);
     order_state_store_tests::add_tests(tests);
     reconciler_logic_tests::add_tests(tests);
+    sequence_tracker_tests::add_tests(tests);
+    reconciler_sequence_tests::add_tests(tests);
     return run_tests(tests);
 }

--- a/tests/from_wire_tests.cpp
+++ b/tests/from_wire_tests.cpp
@@ -12,6 +12,8 @@ bool test_from_wire_roundtrip() {
     core::WireExecEvent wire{};
     wire.exec_type = static_cast<std::uint8_t>(core::ExecType::Fill);
     wire.ord_status = static_cast<std::uint8_t>(core::OrdStatus::Filled);
+    wire.seq_num = 42;
+    wire.session_id = 7;
     wire.price_micro = 123456;
     wire.qty = 1000;
     wire.cum_qty = 2000;
@@ -31,6 +33,7 @@ bool test_from_wire_roundtrip() {
     if (evt.source != core::Source::Primary) return false;
     if (evt.exec_type != core::ExecType::Fill) return false;
     if (evt.ord_status != core::OrdStatus::Filled) return false;
+    if (evt.seq_num != wire.seq_num || evt.session_id != wire.session_id) return false;
     if (evt.price_micro != wire.price_micro || evt.qty != wire.qty || evt.cum_qty != wire.cum_qty) return false;
     if (evt.sending_time != wire.sending_time || evt.transact_time != wire.transact_time) return false;
     if (evt.ingest_tsc != 999) return false;

--- a/tests/integration/aeron_flow_test.cpp
+++ b/tests/integration/aeron_flow_test.cpp
@@ -100,6 +100,8 @@ core::WireExecEvent make_wire_exec(std::size_t seq) {
     core::WireExecEvent evt{};
     evt.exec_type = 2; // Fill
     evt.ord_status = 2; // Filled
+    evt.seq_num = static_cast<std::uint64_t>(seq);
+    evt.session_id = 0;
     evt.price_micro = 1000000 + static_cast<std::int64_t>(seq);
     evt.qty = 100 + static_cast<std::int64_t>(seq);
     evt.cum_qty = evt.qty;
@@ -192,6 +194,7 @@ int main() {
         ingest::ThreadStats dropcopy_stats;
         core::ReconCounters counters;
         core::DivergenceRing divergence_ring;
+        core::SequenceGapRing seq_gap_ring;
         std::atomic<bool> stop_flag{false};
         util::Arena arena(util::Arena::default_capacity_bytes);
         constexpr std::size_t order_capacity_hint = 1u << 12;
@@ -201,7 +204,7 @@ int main() {
         context.aeronDir(aeron_dir.string());
         auto client = aeron::Aeron::connect(context);
 
-        core::Reconciler recon(stop_flag, *primary_ring, *dropcopy_ring, store, counters, divergence_ring);
+        core::Reconciler recon(stop_flag, *primary_ring, *dropcopy_ring, store, counters, divergence_ring, seq_gap_ring);
         ingest::AeronSubscriber primary_sub(primary_channel,
                                             primary_stream,
                                             *primary_ring,

--- a/tests/reconciler_sequence_tests.cpp
+++ b/tests/reconciler_sequence_tests.cpp
@@ -1,0 +1,96 @@
+#include "test_main.hpp"
+
+#include <atomic>
+#include <cstring>
+#include <memory>
+
+#include "core/reconciler.hpp"
+#include "core/order_state_store.hpp"
+#include "ingest/spsc_ring.hpp"
+#include "util/arena.hpp"
+
+namespace reconciler_sequence_tests {
+
+using ExecRing = ingest::SpscRing<core::ExecEvent, 1u << 16>;
+
+core::ExecEvent make_seq_event(core::Source src, std::uint64_t seq, const char* clord) {
+    core::ExecEvent ev{};
+    ev.source = src;
+    ev.seq_num = seq;
+    ev.ord_status = core::OrdStatus::New;
+    ev.exec_type = core::ExecType::New;
+    ev.cum_qty = 0;
+    ev.qty = 0;
+    ev.price_micro = 0;
+    ev.ingest_tsc = seq;
+    ev.set_clord_id(clord, std::strlen(clord));
+    ev.set_exec_id("X", 1);
+    return ev;
+}
+
+struct Harness {
+    std::atomic<bool> stop_flag{false};
+    std::unique_ptr<ExecRing> primary_ring;
+    std::unique_ptr<ExecRing> dropcopy_ring;
+    std::unique_ptr<core::DivergenceRing> divergence_ring;
+    std::unique_ptr<core::SequenceGapRing> seq_gap_ring;
+    util::Arena arena{util::Arena::default_capacity_bytes};
+    core::OrderStateStore store;
+    core::ReconCounters counters{};
+    core::Reconciler reconciler;
+
+    Harness()
+        : primary_ring(std::make_unique<ExecRing>()),
+          dropcopy_ring(std::make_unique<ExecRing>()),
+          divergence_ring(std::make_unique<core::DivergenceRing>()),
+          seq_gap_ring(std::make_unique<core::SequenceGapRing>()),
+          store(arena, 128u),
+          reconciler(stop_flag,
+                     *primary_ring,
+                     *dropcopy_ring,
+                     store,
+                     counters,
+                     *divergence_ring,
+                     *seq_gap_ring) {}
+};
+
+bool test_primary_gap_emitted() {
+    Harness h;
+    auto ev1 = make_seq_event(core::Source::Primary, 1, "CP1");
+    auto ev2 = make_seq_event(core::Source::Primary, 4, "CP1");
+    h.reconciler.process_event_for_test(ev1);
+    h.reconciler.process_event_for_test(ev2);
+
+    core::SequenceGapEvent gap{};
+    if (!h.seq_gap_ring->try_pop(gap)) return false;
+    if (gap.kind != core::GapKind::Gap) return false;
+    return h.counters.primary_seq_gaps == 1 && h.counters.sequence_gap_ring_drops == 0 &&
+           gap.expected_seq == 2 && gap.seen_seq == 4;
+}
+
+bool test_dropcopy_duplicate() {
+    Harness h;
+    auto ev1 = make_seq_event(core::Source::DropCopy, 1, "CD1");
+    auto ev2 = make_seq_event(core::Source::DropCopy, 2, "CD1");
+    auto ev3 = make_seq_event(core::Source::DropCopy, 2, "CD1");
+    h.reconciler.process_event_for_test(ev1);
+    h.reconciler.process_event_for_test(ev2);
+    h.reconciler.process_event_for_test(ev3);
+
+    core::SequenceGapEvent gap{};
+    // Pop both events if present; we expect one duplicate entry
+    bool saw_duplicate = false;
+    while (h.seq_gap_ring->try_pop(gap)) {
+        if (gap.kind == core::GapKind::Duplicate) {
+            saw_duplicate = true;
+        }
+    }
+    return saw_duplicate && h.counters.dropcopy_seq_duplicates == 1 && h.counters.sequence_gap_ring_drops == 0;
+}
+
+void add_tests(std::vector<TestCase>& tests) {
+    tests.push_back({"reconciler_primary_gap_emitted", test_primary_gap_emitted});
+    tests.push_back({"reconciler_dropcopy_duplicate", test_dropcopy_duplicate});
+}
+
+} // namespace reconciler_sequence_tests

--- a/tests/sequence_tracker_tests.cpp
+++ b/tests/sequence_tracker_tests.cpp
@@ -1,0 +1,63 @@
+#include "test_main.hpp"
+
+#include "core/sequence_tracker.hpp"
+
+namespace sequence_tracker_tests {
+
+bool test_init_tracker() {
+    core::SequenceTracker trk{};
+    const bool ok = core::init_sequence_tracker(trk, 10);
+    return ok && trk.initialized && trk.expected_seq == 11 && trk.last_seen_seq == 10 && !trk.gap_open;
+}
+
+bool test_in_order_sequence() {
+    core::SequenceTracker trk{};
+    core::init_sequence_tracker(trk, 1);
+    core::SequenceGapEvent evt{};
+    if (core::track_sequence(trk, core::Source::Primary, 0, 2, 0, &evt)) return false;
+    if (core::track_sequence(trk, core::Source::Primary, 0, 3, 0, &evt)) return false;
+    if (core::track_sequence(trk, core::Source::Primary, 0, 4, 0, &evt)) return false;
+    return trk.expected_seq == 5 && trk.last_seen_seq == 4 && !trk.gap_open;
+}
+
+bool test_forward_gap_detected() {
+    core::SequenceTracker trk{};
+    core::SequenceGapEvent evt{};
+    core::init_sequence_tracker(trk, 1);
+    const bool has_gap = core::track_sequence(trk, core::Source::Primary, 0, 4, 123, &evt);
+    return has_gap &&
+           trk.gap_open &&
+           trk.gap_start_seq == 2 &&
+           evt.kind == core::GapKind::Gap &&
+           evt.expected_seq == 2 &&
+           evt.seen_seq == 4 &&
+           evt.detect_ts == 123;
+}
+
+bool test_duplicate_detected() {
+    core::SequenceTracker trk{};
+    core::SequenceGapEvent evt{};
+    core::init_sequence_tracker(trk, 1);
+    core::track_sequence(trk, core::Source::Primary, 0, 2, 0, &evt);
+    const bool dup = core::track_sequence(trk, core::Source::Primary, 0, 2, 55, &evt);
+    return dup && evt.kind == core::GapKind::Duplicate && evt.seen_seq == 2 && evt.expected_seq == 3;
+}
+
+bool test_out_of_order_detected() {
+    core::SequenceTracker trk{};
+    core::SequenceGapEvent evt{};
+    core::init_sequence_tracker(trk, 1);
+    core::track_sequence(trk, core::Source::Primary, 0, 3, 0, &evt); // opens a gap at 2
+    const bool out_of_order = core::track_sequence(trk, core::Source::Primary, 0, 2, 77, &evt);
+    return out_of_order && evt.kind == core::GapKind::OutOfOrder && evt.expected_seq == 4 && evt.seen_seq == 2;
+}
+
+void add_tests(std::vector<TestCase>& tests) {
+    tests.push_back({"sequence_tracker_init", test_init_tracker});
+    tests.push_back({"sequence_tracker_in_order", test_in_order_sequence});
+    tests.push_back({"sequence_tracker_forward_gap", test_forward_gap_detected});
+    tests.push_back({"sequence_tracker_duplicate", test_duplicate_detected});
+    tests.push_back({"sequence_tracker_out_of_order", test_out_of_order_detected});
+}
+
+} // namespace sequence_tracker_tests


### PR DESCRIPTION
## Summary
- extend wire and normalized execution events with session sequence metadata
- add a production-style sequence tracker, gap event ring, and hook into the reconciler with counters and gap marking
- provide unit coverage for sequence tracking and reconciler gap wiring plus build system updates

## Testing
- cmake -S . -B build (fails: Aeron client not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694731f179b88328ad16638aa5000d6f)