### PR TITLE
Harden replay determinism and verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(fx_dropcopy_recon CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+option(FX_ENABLE_AERON "Build Aeron-dependent components" ON)
 
 if(MSVC)
   add_compile_options(/W4 /permissive-)
@@ -58,6 +59,7 @@ add_library(fx_core
 
 target_include_directories(fx_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
+if(FX_ENABLE_AERON)
 # Try config-based discovery first; fall back to manual lookup if Aeron does not
 # ship a CMake package config in the current environment (e.g., custom install
 # from source).
@@ -182,32 +184,34 @@ if(NOT aeron_FOUND)
     INTERFACE_INCLUDE_DIRECTORIES "${AERON_INCLUDE_DIRS}"
   )
 endif()
+endif()
 
 add_executable(fx_ingest_demo src/api/demo_main.cpp src/ingest/fix_parser.cpp src/core/reconciler.cpp)
 target_link_libraries(fx_ingest_demo PRIVATE fx_core)
 
-add_executable(fx_exec_recond
-    src/api/recond_main.cpp
-    src/ingest/aeron_subscriber.cpp
-    src/core/reconciler.cpp
-)
-target_link_libraries(fx_exec_recond PRIVATE fx_core aeron::aeron_client)
+if(FX_ENABLE_AERON)
+  add_executable(fx_exec_recond
+      src/api/recond_main.cpp
+      src/ingest/aeron_subscriber.cpp
+      src/core/reconciler.cpp
+  )
+  target_link_libraries(fx_exec_recond PRIVATE fx_core aeron::aeron_client)
 
-add_executable(fx_aeron_publisher
-    src/api/aeron_publisher.cpp
-)
-target_link_libraries(fx_aeron_publisher PRIVATE fx_core aeron::aeron_client)
+  add_executable(fx_aeron_publisher
+      src/api/aeron_publisher.cpp
+  )
+  target_link_libraries(fx_aeron_publisher PRIVATE fx_core aeron::aeron_client)
+endif()
 
 add_executable(fx_replay_main
     src/api/replay_main.cpp
 )
 target_link_libraries(fx_replay_main PRIVATE fx_core)
 
-add_executable(unit_tests_gtest
+set(TEST_SOURCES
     tests/ring_tests.cpp
     tests/fix_parser_tests.cpp
     tests/from_wire_tests.cpp
-    tests/aeron_subscriber_tests.cpp
     tests/arena_tests.cpp
     tests/order_state_tests.cpp
     tests/order_lifecycle_tests.cpp
@@ -224,25 +228,38 @@ add_executable(unit_tests_gtest
     tests/audit_log_integration_tests.cpp
     tests/replay_integration_tests.cpp
 )
-target_sources(unit_tests_gtest PRIVATE src/ingest/aeron_subscriber.cpp)
+if(FX_ENABLE_AERON)
+  list(APPEND TEST_SOURCES tests/aeron_subscriber_tests.cpp)
+endif()
+
+add_executable(unit_tests_gtest ${TEST_SOURCES})
+if(FX_ENABLE_AERON)
+  target_sources(unit_tests_gtest PRIVATE src/ingest/aeron_subscriber.cpp)
+endif()
 target_include_directories(unit_tests_gtest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
-target_link_libraries(unit_tests_gtest PRIVATE fx_core aeron::aeron_client GTest::gtest_main)
+if(FX_ENABLE_AERON)
+  target_link_libraries(unit_tests_gtest PRIVATE fx_core aeron::aeron_client GTest::gtest_main)
+else()
+  target_link_libraries(unit_tests_gtest PRIVATE fx_core GTest::gtest_main)
+endif()
 
 gtest_discover_tests(unit_tests_gtest
   TEST_PREFIX unit_
   DISCOVERY_MODE PRE_TEST
 )
 
-add_executable(integration_aeron_flow
-    tests/integration/aeron_flow_test.cpp
-    src/ingest/aeron_subscriber.cpp
-)
-target_link_libraries(integration_aeron_flow PRIVATE fx_core aeron::aeron_client GTest::gtest_main)
+if(FX_ENABLE_AERON)
+  add_executable(integration_aeron_flow
+      tests/integration/aeron_flow_test.cpp
+      src/ingest/aeron_subscriber.cpp
+  )
+  target_link_libraries(integration_aeron_flow PRIVATE fx_core aeron::aeron_client GTest::gtest_main)
 
-gtest_discover_tests(integration_aeron_flow
-  TEST_PREFIX integration_aeron_flow_
-  DISCOVERY_MODE PRE_TEST
-)
+  gtest_discover_tests(integration_aeron_flow
+    TEST_PREFIX integration_aeron_flow_
+    DISCOVERY_MODE PRE_TEST
+  )
+endif()
 
 add_executable(benchmarks bench/bench_main.cpp src/ingest/fix_parser.cpp src/core/reconciler.cpp)
 target_link_libraries(benchmarks PRIVATE fx_core)

--- a/src/api/recond_main.cpp
+++ b/src/api/recond_main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
     aeron::Context context;
     auto client = aeron::Aeron::connect(context);
 
-    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, store, counters, divergence_ring, seq_gap_ring, &audit_counters);
+    core::Reconciler recon(stop_flag, primary_ring, dropcopy_ring, store, counters, divergence_ring, seq_gap_ring, &audit_counters, &stop_flag);
 
     persist::WireCaptureConfig capture_cfg;
     persist::WireCaptureWriter capture_writer(std::move(capture_cfg));

--- a/src/api/replay_main.cpp
+++ b/src/api/replay_main.cpp
@@ -18,7 +18,7 @@ void print_usage(const char* prog) {
               << "  --to-ns <uint64>        Optional inclusive end timestamp (ns)\n"
               << "  --speed <double>        Playback speed multiplier (default 1.0)\n"
               << "  --fast                  Process without sleeping (overrides --speed)\n"
-              << "  --out-dir <path>        Output directory for audit logs (default ./replay_out/<ts>)\n"
+              << "  --out-dir <path>        Output directory for audit logs (default ./replay_out)\n"
               << "  --verify-against <dir>  Compare outputs against golden directory\n"
               << "  --max-records <N>       Optional cap on records processed\n"
               << "  --quiet                 Suppress non-error logs\n"
@@ -38,19 +38,8 @@ std::vector<std::filesystem::path> split_files(const std::string& s) {
 }
 
 std::filesystem::path default_output_dir() {
-    const auto now = std::chrono::system_clock::now();
-    const std::time_t t = std::chrono::system_clock::to_time_t(now);
-    std::tm tm{};
-#if defined(_WIN32)
-    localtime_s(&tm, &t);
-#else
-    localtime_r(&t, &tm);
-#endif
-    char buf[64];
-    std::snprintf(buf, sizeof(buf), "replay_out/%04d%02d%02d_%02d%02d%02d",
-                  tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                  tm.tm_hour, tm.tm_min, tm.tm_sec);
-    return std::filesystem::path(buf);
+    // Deterministic default to keep replay outputs stable across runs.
+    return std::filesystem::path("replay_out");
 }
 
 } // namespace

--- a/src/core/exec_event.hpp
+++ b/src/core/exec_event.hpp
@@ -36,7 +36,7 @@ struct ExecEvent {
     int64_t cum_qty{0};
     uint64_t sending_time{0};
     uint64_t transact_time{0};
-    uint64_t ingest_tsc{0};
+    uint64_t ingest_timestamp_ns{0};
 
     static constexpr std::size_t id_capacity = 32;
     char exec_id[id_capacity]{};
@@ -63,7 +63,7 @@ struct ExecEvent {
     }
 };
 
-inline ExecEvent from_wire(const WireExecEvent& w, Source src, uint64_t ingest_tsc) noexcept {
+inline ExecEvent from_wire(const WireExecEvent& w, Source src, uint64_t ingest_timestamp_ns) noexcept {
     static_assert(ExecEvent::id_capacity == WireExecEvent::id_capacity,
                   "ExecEvent and WireExecEvent must agree on id capacity");
     ExecEvent evt{};
@@ -77,7 +77,7 @@ inline ExecEvent from_wire(const WireExecEvent& w, Source src, uint64_t ingest_t
     evt.cum_qty = w.cum_qty;
     evt.sending_time = w.sending_time;
     evt.transact_time = w.transact_time;
-    evt.ingest_tsc = ingest_tsc;
+    evt.ingest_timestamp_ns = ingest_timestamp_ns;
 
     const auto exec_len = static_cast<std::size_t>(
         w.exec_id_len > WireExecEvent::id_capacity ? WireExecEvent::id_capacity : w.exec_id_len);

--- a/src/core/reconciler.hpp
+++ b/src/core/reconciler.hpp
@@ -55,7 +55,8 @@ public:
                ReconCounters& counters,
                DivergenceRing& divergence_ring,
                SequenceGapRing& seq_gap_ring,
-               persist::AuditLogCounters* audit_counters = nullptr) noexcept;
+               persist::AuditLogCounters* audit_counters = nullptr,
+               std::atomic<bool>* producer_done = nullptr) noexcept;
 
     void run();
     void process_event_for_test(const ExecEvent& ev) noexcept { process_event(ev); }
@@ -76,6 +77,7 @@ private:
     DivergenceRing& divergence_ring_;
     SequenceGapRing& seq_gap_ring_;
     persist::AuditLogCounters* audit_counters_;
+    std::atomic<bool>* producer_done_;
 
     SequenceTracker primary_seq_tracker_{};
     SequenceTracker dropcopy_seq_tracker_{};

--- a/src/ingest/fix_parser.cpp
+++ b/src/ingest/fix_parser.cpp
@@ -149,7 +149,7 @@ ParseResult parse_exec_report(const char* data, std::size_t len, core::ExecEvent
         }
     }
 
-    out.ingest_tsc = util::rdtsc();
+    out.ingest_timestamp_ns = util::rdtsc();
 
     if (out.order_id_len == 0 && out.clord_id_len == 0) {
         return ParseResult::MissingField;

--- a/tests/from_wire_tests.cpp
+++ b/tests/from_wire_tests.cpp
@@ -43,7 +43,7 @@ TEST(WireExecTest, FromWireRoundtrip) {
     EXPECT_EQ(evt.cum_qty, wire.cum_qty);
     EXPECT_EQ(evt.sending_time, wire.sending_time);
     EXPECT_EQ(evt.transact_time, wire.transact_time);
-    EXPECT_EQ(evt.ingest_tsc, 999);
+    EXPECT_EQ(evt.ingest_timestamp_ns, 999);
 
     ASSERT_EQ(evt.exec_id_len, wire.exec_id_len);
     EXPECT_EQ(std::string_view(evt.exec_id, evt.exec_id_len), std::string_view(exec_id));

--- a/tests/reconciler_sequence_tests.cpp
+++ b/tests/reconciler_sequence_tests.cpp
@@ -51,7 +51,7 @@ protected:
         ev.cum_qty = 0;
         ev.qty = 0;
         ev.price_micro = 0;
-        ev.ingest_tsc = seq;
+        ev.ingest_timestamp_ns = seq;
         ev.set_clord_id(clord, std::strlen(clord));
         ev.set_exec_id("X", 1);
         return ev;


### PR DESCRIPTION
## Summary
- Make the replay loop deterministic by using capture timestamps, bounding ring backpressure retries, and returning detailed verification mismatches when comparing outputs.
- Remove timestamp-based output naming by default and switch audit log filenames to deterministic sequence numbers.
- Broaden replay integration coverage with a 100-record gap/divergence scenario, time-window filtering, and intentional mismatch verification, and add an Aeron opt-out for environments without the client.

## Testing
- ctest --test-dir build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69493d00e9288328b485e341954f1f63)