### PR TITLE
Add incident regression diff harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ add_library(fx_core
     src/persist/endianness.hpp
     src/persist/audit_log_format.hpp
     src/persist/audit_log_writer.cpp
+    src/persist/incident_spec.cpp
+    src/persist/audit_diff.cpp
     src/api/replay.cpp
 )
 
@@ -227,6 +229,7 @@ set(TEST_SOURCES
     tests/audit_log_writer_tests.cpp
     tests/audit_log_integration_tests.cpp
     tests/replay_integration_tests.cpp
+    tests/audit_diff_tests.cpp
 )
 if(FX_ENABLE_AERON)
   list(APPEND TEST_SOURCES tests/aeron_subscriber_tests.cpp)

--- a/incidents/INC-2025-EXAMPLE/README.md
+++ b/incidents/INC-2025-EXAMPLE/README.md
@@ -1,0 +1,24 @@
+# INC-2025-EXAMPLE
+
+This example incident demonstrates the deterministic replay + audit comparison workflow.
+
+## Files
+- `spec.json`: Example incident definition.
+- `whitelist.json`: Example whitelist exercising all rule types.
+
+## Usage
+1. Generate golden outputs from a trusted baseline:
+   ```bash
+   replay_main --incident incidents/INC-2025-EXAMPLE/spec.json \
+               --config configs/baseline.json \
+               --output incidents/INC-2025-EXAMPLE/golden
+   ```
+2. Test a candidate build and compare against the golden:
+   ```bash
+   replay_main --incident incidents/INC-2025-EXAMPLE/spec.json \
+               --config configs/candidate.json \
+               --output /tmp/candidate
+
+   audit_diff incidents/INC-2025-EXAMPLE/golden /tmp/candidate \
+              --whitelist incidents/INC-2025-EXAMPLE/whitelist.json
+   ```

--- a/incidents/INC-2025-EXAMPLE/spec.json
+++ b/incidents/INC-2025-EXAMPLE/spec.json
@@ -1,0 +1,20 @@
+{
+  "id": "INC-2025-EXAMPLE",
+  "description": "Example incident for audit regression harness",
+  "wire_inputs": [
+    {
+      "path": "wire/demo_20250101_120000.bin",
+      "from_ns": 1735732800000000000,
+      "to_ns": 1735732803000000000
+    },
+    {
+      "path": "wire/demo_20250101_120300.bin",
+      "from_ns": 1735732980000000000,
+      "to_ns": 1735733000000000000
+    }
+  ],
+  "replay": {
+    "speed": "fast",
+    "max_records": 0
+  }
+}

--- a/incidents/INC-2025-EXAMPLE/whitelist.json
+++ b/incidents/INC-2025-EXAMPLE/whitelist.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "rules": [
+    {
+      "type": "ignore_divergence_type",
+      "divergence_type": "QuantityMismatch",
+      "venue": "EBS",
+      "reason": "Known rounding difference"
+    },
+    {
+      "type": "ignore_n_occurrences",
+      "divergence_type": "StateMismatch",
+      "max_occurrences": 3,
+      "reason": "Transient during restart"
+    },
+    {
+      "type": "ignore_by_order_key",
+      "order_keys": ["hash:123456789", "clordid:TEST123", "EBS:DEMO001"],
+      "reason": "Test fixture orders"
+    },
+    {
+      "type": "allow_extra_files",
+      "patterns": ["*.tmp", "debug_*"],
+      "reason": "Debug outputs from local runs"
+    }
+  ]
+}

--- a/incidents/README.md
+++ b/incidents/README.md
@@ -1,0 +1,90 @@
+# Incident Specifications
+
+Incident specifications define deterministic replay inputs and expected outputs to support audit regression. Each incident lives under `incidents/<ID>/` and contains:
+
+- `spec.json`: Incident definition (wire inputs and replay parameters).
+- `golden/`: Golden outputs produced once from a trusted baseline build.
+- `whitelist.json` (optional): Known-acceptable differences during comparisons.
+- `README.md` (optional): Notes specific to the incident.
+
+## Format (spec.json)
+
+```json
+{
+  "id": "INC-2025-0001",
+  "description": "EBS sequence gap handling bug",
+  "wire_inputs": [
+    {
+      "path": "wire/ebs_20250101_120000.bin",
+      "from_ns": 1735732800000000000,
+      "to_ns": 1735732805000000000
+    }
+  ],
+  "replay": {
+    "speed": "fast",
+    "max_records": 0
+  }
+}
+```
+
+- `wire_inputs`: One or more segments of wire logs to replay.
+- `replay.speed`: `"fast"` for unthrottled playback (default), `"realtime"` for paced playback.
+- `replay.max_records`: 0 means no limit.
+
+## Workflow
+
+1. **Generate golden outputs (run once):**
+
+   ```bash
+   replay_main --incident incidents/<ID>/spec.json \
+               --config configs/baseline.json \
+               --output incidents/<ID>/golden
+   ```
+
+2. **Test a candidate build (repeatable):**
+
+   ```bash
+   replay_main --incident incidents/<ID>/spec.json \
+               --config configs/candidate.json \
+               --output /tmp/candidate
+
+   audit_diff incidents/<ID>/golden /tmp/candidate \
+              --whitelist incidents/<ID>/whitelist.json
+   ```
+
+## Whitelist (whitelist.json)
+
+```json
+{
+  "version": 1,
+  "rules": [
+    {
+      "type": "ignore_divergence_type",
+      "divergence_type": "QuantityMismatch",
+      "reason": "Known rounding"
+    },
+    {
+      "type": "ignore_n_occurrences",
+      "divergence_type": "StateMismatch",
+      "max_occurrences": 5,
+      "reason": "Acceptable during restart"
+    },
+    {
+      "type": "ignore_by_order_key",
+      "order_keys": ["hash:123456789", "clordid:ABC123"],
+      "reason": "Test orders"
+    },
+    {
+      "type": "allow_extra_files",
+      "patterns": ["*.tmp", "debug_*"],
+      "reason": "Debug outputs"
+    }
+  ]
+}
+```
+
+- Rules are evaluated in order. The first matching rule determines whether a difference is whitelisted.
+- `order_keys` supports:
+  - `hash:<uint64>`: exact audit key.
+  - `clordid:<literal>`: hashed with the same FNV-1a algorithm used in audit records.
+  - `<legacy>` strings like `EBS:12345` are hashed **including** the entire literal for backward compatibility.

--- a/src/persist/audit_diff.cpp
+++ b/src/persist/audit_diff.cpp
@@ -1,0 +1,522 @@
+#include "persist/audit_diff.hpp"
+
+#include <algorithm>
+#include <array>
+#include <charconv>
+#include <fstream>
+#include <cstring>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <utility>
+
+#include "persist/audit_log_format.hpp"
+
+namespace persist {
+namespace {
+
+constexpr std::size_t kChunkSize = 64 * 1024;
+constexpr std::size_t kMaxRecordBytes = 1024 * 1024;
+constexpr std::size_t kMaxReportMismatches = 10;
+
+struct RecordData {
+    DecodedRecord decoded;
+    std::vector<std::byte> raw;
+    std::uint64_t offset{0};
+};
+
+class RecordStreamParser {
+public:
+    bool feed(std::span<const std::byte> data) {
+        buffer_.insert(buffer_.end(), data.begin(), data.end());
+        if (buffer_.size() > kMaxRecordBytes) {
+            return false;
+        }
+        return true;
+    }
+
+    enum class Status { Ok, NeedMore, Error, End };
+
+    Status next_record(RecordData& out, std::string& err) {
+        using enum Status;
+        if (buffer_.empty()) {
+            return NeedMore;
+        }
+        if (buffer_.size() < header_size) {
+            return NeedMore;
+        }
+        const auto payload_len = load_le32(buffer_.data() + sizeof(std::uint32_t));
+        const std::size_t total = header_size + payload_len + trailer_size;
+        if (total > kMaxRecordBytes) {
+            err = "Record exceeds max size";
+            return Error;
+        }
+        if (buffer_.size() < total) {
+            return NeedMore;
+        }
+        std::span<const std::byte> rec_span(buffer_.data(), total);
+        DecodedRecord decoded{};
+        const auto res = decode_record(rec_span, decoded);
+        if (res != DecodeError::Ok) {
+            if (is_graceful_eof(res) && total == header_size) {
+                return End;
+            }
+            err = "Failed to decode record";
+            return Error;
+        }
+        out.raw.assign(buffer_.begin(), buffer_.begin() + static_cast<std::ptrdiff_t>(total));
+        out.decoded = decoded;
+        out.offset = offset_;
+        buffer_.erase(buffer_.begin(), buffer_.begin() + static_cast<std::ptrdiff_t>(total));
+        offset_ += total;
+        return Ok;
+    }
+
+    bool empty() const noexcept { return buffer_.empty(); }
+
+private:
+    std::vector<std::byte> buffer_;
+    std::uint64_t offset_{0};
+};
+
+struct MismatchDetail {
+    std::filesystem::path file;
+    std::uint64_t offset{0};
+    std::size_t record_index{0};
+    std::vector<std::byte> expected;
+    std::vector<std::byte> actual;
+    std::size_t first_diff{0};
+    bool whitelisted{false};
+    std::string whitelist_reason;
+};
+
+struct ExtraFileDetail {
+    std::filesystem::path file;
+    bool allowed{false};
+};
+
+std::string to_hex_bytes(std::span<const std::byte> data) {
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        if (i > 0) {
+            oss << ' ';
+        }
+        oss << "0x" << std::setw(2)
+            << static_cast<unsigned int>(static_cast<unsigned char>(data[i]));
+    }
+    return oss.str();
+}
+
+bool list_files(const std::filesystem::path& root, std::vector<std::filesystem::path>& out) {
+    if (!std::filesystem::exists(root)) {
+        return false;
+    }
+    for (auto it = std::filesystem::recursive_directory_iterator(root); it != std::filesystem::recursive_directory_iterator(); ++it) {
+        if (it->is_regular_file()) {
+            out.push_back(std::filesystem::relative(it->path(), root).lexically_normal());
+        }
+    }
+    auto comp = [](const std::filesystem::path& a, const std::filesystem::path& b) {
+        return a.lexically_normal().generic_string() < b.lexically_normal().generic_string();
+    };
+    std::sort(out.begin(), out.end(), comp);
+    return true;
+}
+
+bool match_allow_patterns(const Whitelist& wl, const std::filesystem::path& file) {
+    const auto fname = file.filename().generic_string();
+    for (const auto& rule : wl.rules) {
+        if (rule.type != WhitelistRuleType::AllowExtraFiles) {
+            continue;
+        }
+        for (const auto& pat : rule.patterns) {
+            if (wildcard_match(pat, fname)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+std::string describe_rule(const WhitelistRule& rule) {
+    switch (rule.type) {
+        case WhitelistRuleType::IgnoreDivergenceType:
+            return "ignore_divergence_type";
+        case WhitelistRuleType::IgnoreNOccurrences:
+            return "ignore_n_occurrences";
+        case WhitelistRuleType::IgnoreByOrderKey:
+            return "ignore_by_order_key";
+        case WhitelistRuleType::AllowExtraFiles:
+            return "allow_extra_files";
+    }
+    return "unknown";
+}
+
+bool match_rule(const WhitelistRule& rule, const DecodedRecord& actual, std::size_t& remaining) {
+    if (rule.type == WhitelistRuleType::AllowExtraFiles) {
+        return false; // handled separately
+    }
+    if (actual.type != AuditRecordType::Divergence) {
+        return false;
+    }
+    if (rule.type == WhitelistRuleType::IgnoreByOrderKey) {
+        return std::find(rule.order_keys.begin(), rule.order_keys.end(), actual.divergence.key) != rule.order_keys.end();
+    }
+    if (rule.divergence_type != actual.divergence.type) {
+        return false;
+    }
+    if (!rule.venue.empty()) {
+        // Venue not encoded; ignore venue filter.
+    }
+    if (rule.type == WhitelistRuleType::IgnoreNOccurrences) {
+        if (rule.remaining_occurrences == 0) {
+            return false;
+        }
+        remaining = rule.remaining_occurrences - 1;
+    }
+    return true;
+}
+
+bool apply_whitelist(Whitelist& wl, const DecodedRecord& actual, std::string& reason) {
+    for (auto& rule : wl.rules) {
+        std::size_t remaining = rule.remaining_occurrences;
+        if (match_rule(rule, actual, remaining)) {
+            if (rule.type == WhitelistRuleType::IgnoreNOccurrences) {
+                rule.remaining_occurrences = remaining;
+            }
+            reason = rule.reason.empty() ? describe_rule(rule) : rule.reason;
+            return true;
+        }
+    }
+    return false;
+}
+
+class ChunkedReader {
+public:
+    explicit ChunkedReader(const std::filesystem::path& path)
+        : stream_(path, std::ios::binary), path_(path) {}
+
+    bool ok() const { return stream_.good(); }
+
+    enum class FetchResult { Record, End, Error };
+
+    FetchResult fetch(RecordStreamParser& parser, RecordData& out, std::string& err) {
+        while (true) {
+            auto status = parser.next_record(out, err);
+            if (status == RecordStreamParser::Status::Ok) {
+                return FetchResult::Record;
+            }
+            if (status == RecordStreamParser::Status::Error) {
+                return FetchResult::Error;
+            }
+            if (!stream_) {
+                if (parser.empty()) {
+                    err.clear();
+                    return FetchResult::End;
+                }
+                err = "Truncated record";
+                return FetchResult::Error;
+            }
+            std::array<std::byte, kChunkSize> buf{};
+            stream_.read(reinterpret_cast<char*>(buf.data()), static_cast<std::streamsize>(buf.size()));
+            const auto got = stream_.gcount();
+            if (got <= 0) {
+                stream_.setstate(std::ios::eofbit);
+                continue;
+            }
+            if (!parser.feed(std::span<const std::byte>(buf.data(), static_cast<std::size_t>(got)))) {
+                err = "Record exceeds max size";
+                return FetchResult::Error;
+            }
+        }
+    }
+
+    bool eof() const {
+        return stream_.eof();
+    }
+
+private:
+    std::ifstream stream_;
+    std::filesystem::path path_;
+};
+
+std::size_t first_diff_offset(std::span<const std::byte> a, std::span<const std::byte> b) {
+    const std::size_t n = std::min(a.size(), b.size());
+    for (std::size_t i = 0; i < n; ++i) {
+        if (a[i] != b[i]) {
+            return i;
+        }
+    }
+    return n;
+}
+
+DiffResult diff_audit_records(const std::filesystem::path& expected_path,
+                              const std::filesystem::path& actual_path,
+                              Whitelist* wl,
+                              const DiffOptions& options,
+                              DiffStats& stats,
+                              std::vector<MismatchDetail>& mismatches) {
+    ChunkedReader expected_reader(expected_path);
+    ChunkedReader actual_reader(actual_path);
+    if (!expected_reader.ok() || !actual_reader.ok()) {
+        return DiffResult::IoError;
+    }
+    RecordStreamParser expected_parser;
+    RecordStreamParser actual_parser;
+    RecordData expected_record;
+    RecordData actual_record;
+    std::size_t record_index = 0;
+    std::string err_exp;
+    std::string err_act;
+    while (true) {
+        auto have_exp = expected_reader.fetch(expected_parser, expected_record, err_exp);
+        auto have_act = actual_reader.fetch(actual_parser, actual_record, err_act);
+        if (have_exp == ChunkedReader::FetchResult::End && have_act == ChunkedReader::FetchResult::End) {
+            break; // both exhausted
+        }
+        if (have_exp != ChunkedReader::FetchResult::Record || have_act != ChunkedReader::FetchResult::Record) {
+            MismatchDetail detail;
+            detail.file = expected_path.filename();
+            detail.offset = (have_exp == ChunkedReader::FetchResult::Record) ? expected_record.offset : actual_record.offset;
+            detail.record_index = record_index;
+            if (have_exp == ChunkedReader::FetchResult::Error || have_act == ChunkedReader::FetchResult::Error) {
+                return DiffResult::BadFormat;
+            }
+            mismatches.push_back(std::move(detail));
+            ++stats.mismatches;
+            break;
+        }
+        ++record_index;
+        ++stats.records_compared;
+        stats.bytes_compared += std::min(expected_record.raw.size(), actual_record.raw.size());
+        if (expected_record.raw == actual_record.raw) {
+            continue;
+        }
+        bool whitelisted = false;
+        std::string reason;
+        if (options.allow_whitelist && wl) {
+            whitelisted = apply_whitelist(*wl, actual_record.decoded, reason);
+        }
+        MismatchDetail detail;
+        detail.file = expected_path.filename();
+        detail.offset = expected_record.offset;
+        detail.record_index = record_index - 1;
+        detail.first_diff = first_diff_offset(expected_record.raw, actual_record.raw);
+        const std::size_t window = 16;
+        const std::size_t start = detail.first_diff;
+        const std::size_t exp_len = std::min(window, expected_record.raw.size() - start);
+        const std::size_t act_len = std::min(window, actual_record.raw.size() - start);
+        detail.expected.assign(expected_record.raw.begin() + static_cast<std::ptrdiff_t>(start),
+                               expected_record.raw.begin() + static_cast<std::ptrdiff_t>(start + exp_len));
+        detail.actual.assign(actual_record.raw.begin() + static_cast<std::ptrdiff_t>(start),
+                             actual_record.raw.begin() + static_cast<std::ptrdiff_t>(start + act_len));
+        detail.whitelisted = whitelisted;
+        detail.whitelist_reason = reason;
+        if (whitelisted) {
+            ++stats.whitelisted;
+        } else {
+            ++stats.mismatches;
+        }
+        if (!whitelisted && mismatches.size() < kMaxReportMismatches) {
+            mismatches.push_back(std::move(detail));
+        } else if (whitelisted && mismatches.size() < kMaxReportMismatches) {
+            mismatches.push_back(std::move(detail));
+        }
+    }
+    if (!err_exp.empty() || !err_act.empty()) {
+        return DiffResult::BadFormat;
+    }
+    return DiffResult::Match;
+}
+
+DiffResult diff_binary_files(const std::filesystem::path& expected_path,
+                             const std::filesystem::path& actual_path,
+                             DiffStats& stats,
+                             std::vector<MismatchDetail>& mismatches) {
+    std::ifstream exp(expected_path, std::ios::binary);
+    std::ifstream act(actual_path, std::ios::binary);
+    if (!exp || !act) {
+        return DiffResult::IoError;
+    }
+    std::array<char, kChunkSize> buf_exp{};
+    std::array<char, kChunkSize> buf_act{};
+    std::uint64_t offset = 0;
+    while (true) {
+        exp.read(buf_exp.data(), static_cast<std::streamsize>(buf_exp.size()));
+        act.read(buf_act.data(), static_cast<std::streamsize>(buf_act.size()));
+        const auto got_e = exp.gcount();
+        const auto got_a = act.gcount();
+        if (got_e <= 0 && got_a <= 0) {
+            break;
+        }
+        const std::size_t n = static_cast<std::size_t>(std::min(got_e, got_a));
+        stats.bytes_compared += n;
+        if (n > 0) {
+            if (std::memcmp(buf_exp.data(), buf_act.data(), n) != 0) {
+                MismatchDetail detail;
+                detail.file = expected_path.filename();
+                detail.offset = offset + first_diff_offset(
+                    std::span<const std::byte>(reinterpret_cast<const std::byte*>(buf_exp.data()), n),
+                    std::span<const std::byte>(reinterpret_cast<const std::byte*>(buf_act.data()), n));
+                detail.record_index = 0;
+                mismatches.push_back(std::move(detail));
+                ++stats.mismatches;
+                return DiffResult::Mismatch;
+            }
+        }
+        if (got_e != got_a) {
+            MismatchDetail detail;
+            detail.file = expected_path.filename();
+            detail.offset = offset + n;
+            detail.record_index = 0;
+            mismatches.push_back(std::move(detail));
+            ++stats.mismatches;
+            return DiffResult::Mismatch;
+        }
+        offset += n;
+    }
+    return DiffResult::Match;
+}
+
+std::string build_report(DiffResult result,
+                         const DiffStats& stats,
+                         const std::vector<MismatchDetail>& mismatches,
+                         const std::vector<ExtraFileDetail>& extras) {
+    std::ostringstream oss;
+    oss << "--- Audit Diff Report ---\n";
+    oss << "Status: " << (result == DiffResult::Match && stats.mismatches == 0 ? "Match" : "Mismatch") << "\n";
+    oss << "Files compared: " << stats.files_compared << "\n";
+    oss << "Records compared: " << stats.records_compared << "\n";
+    oss << "Mismatches: " << stats.mismatches << "\n";
+    oss << "Whitelisted: " << stats.whitelisted << "\n\n";
+    if (!mismatches.empty()) {
+        std::size_t idx = 1;
+        for (const auto& m : mismatches) {
+            oss << "Mismatch " << idx++ << ":\n";
+            oss << "  File: " << m.file.generic_string() << "\n";
+            oss << "  Offset: " << m.offset << " (0x" << std::hex << m.offset << std::dec << ")\n";
+            oss << "  Record index: " << m.record_index << "\n";
+            if (!m.expected.empty() || !m.actual.empty()) {
+                oss << "  Expected: " << to_hex_bytes(m.expected) << "\n";
+                oss << "  Actual:   " << to_hex_bytes(m.actual) << "\n";
+                oss << "  First diff at byte " << m.first_diff << "\n";
+            }
+            if (m.whitelisted) {
+                oss << "  Whitelist rule: " << m.whitelist_reason << "\n";
+            }
+            oss << "\n";
+        }
+    }
+    if (!extras.empty()) {
+        oss << "Extra files in actual:\n";
+        for (const auto& e : extras) {
+            oss << "  - " << e.file.generic_string() << " (" << (e.allowed ? "allowed" : "not allowed") << ")\n";
+        }
+    }
+    oss << "--- End Report ---\n";
+    return oss.str();
+}
+
+} // namespace
+
+DiffResult diff_directories(
+    const std::filesystem::path& expected_dir,
+    const std::filesystem::path& actual_dir,
+    const DiffOptions& options,
+    DiffStats& stats,
+    std::string& out_report
+) noexcept {
+    stats = {};
+    Whitelist whitelist;
+    Whitelist* wl_ptr = nullptr;
+    if (options.allow_whitelist && !options.whitelist_path.empty()) {
+        std::string err;
+        if (!parse_whitelist(options.whitelist_path, whitelist, err)) {
+            out_report = err;
+            return DiffResult::BadWhitelist;
+        }
+        wl_ptr = &whitelist;
+    }
+
+    std::vector<std::filesystem::path> expected_files;
+    std::vector<std::filesystem::path> actual_files;
+    if (!list_files(expected_dir, expected_files) || !list_files(actual_dir, actual_files)) {
+        out_report = "Failed to list directories";
+        return DiffResult::IoError;
+    }
+    std::vector<ExtraFileDetail> extras;
+    std::size_t exp_idx = 0;
+    std::size_t act_idx = 0;
+    std::vector<MismatchDetail> mismatches;
+    auto normalize = [](const std::filesystem::path& p) {
+        return p.lexically_normal().generic_string();
+    };
+    while (exp_idx < expected_files.size() && act_idx < actual_files.size()) {
+        const auto& exp_rel = expected_files[exp_idx];
+        const auto& act_rel = actual_files[act_idx];
+        const auto exp_norm = normalize(exp_rel);
+        const auto act_norm = normalize(act_rel);
+        if (exp_norm == act_norm) {
+            const auto exp_path = expected_dir / exp_rel;
+            const auto act_path = actual_dir / act_rel;
+            ++stats.files_compared;
+            DiffResult res;
+            if (options.byte_for_byte && (wl_ptr == nullptr || wl_ptr->empty())) {
+                res = diff_binary_files(exp_path, act_path, stats, mismatches);
+            } else {
+                res = diff_audit_records(exp_path, act_path, wl_ptr, options, stats, mismatches);
+            }
+            if (res == DiffResult::IoError || res == DiffResult::BadFormat) {
+                out_report = "Error diffing file: " + exp_rel.generic_string();
+                return res;
+            }
+            ++exp_idx;
+            ++act_idx;
+            continue;
+        }
+        if (exp_norm < act_norm) {
+            MismatchDetail detail;
+            detail.file = exp_rel;
+            mismatches.push_back(std::move(detail));
+            ++stats.mismatches;
+            ++exp_idx;
+        } else {
+            ExtraFileDetail extra;
+            extra.file = act_rel;
+            extra.allowed = wl_ptr && match_allow_patterns(*wl_ptr, act_rel);
+            if (!extra.allowed) {
+                ++stats.mismatches;
+            } else {
+                ++stats.whitelisted;
+            }
+            extras.push_back(extra);
+            ++act_idx;
+        }
+    }
+    while (exp_idx < expected_files.size()) {
+        MismatchDetail detail;
+        detail.file = expected_files[exp_idx];
+        mismatches.push_back(std::move(detail));
+        ++stats.mismatches;
+        ++exp_idx;
+    }
+    while (act_idx < actual_files.size()) {
+        ExtraFileDetail extra;
+        extra.file = actual_files[act_idx];
+        extra.allowed = wl_ptr && match_allow_patterns(*wl_ptr, actual_files[act_idx]);
+        if (!extra.allowed) {
+            ++stats.mismatches;
+        } else {
+            ++stats.whitelisted;
+        }
+        extras.push_back(extra);
+        ++act_idx;
+    }
+
+    const DiffResult overall = stats.mismatches == 0 ? DiffResult::Match : DiffResult::Mismatch;
+    out_report = build_report(overall, stats, mismatches, extras);
+    return overall;
+}
+
+} // namespace persist

--- a/src/persist/audit_diff.hpp
+++ b/src/persist/audit_diff.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+#include "persist/incident_spec.hpp"
+
+namespace persist {
+
+struct DiffOptions {
+    bool byte_for_byte{true};
+    bool allow_whitelist{true};
+    std::filesystem::path whitelist_path;
+};
+
+struct DiffStats {
+    std::size_t files_compared{0};
+    std::size_t bytes_compared{0};
+    std::size_t records_compared{0};
+    std::size_t mismatches{0};
+    std::size_t whitelisted{0};
+};
+
+enum class DiffResult {
+    Match,
+    Mismatch,
+    IoError,
+    BadFormat,
+    BadWhitelist
+};
+
+DiffResult diff_directories(
+    const std::filesystem::path& expected_dir,
+    const std::filesystem::path& actual_dir,
+    const DiffOptions& options,
+    DiffStats& stats,
+    std::string& out_report
+) noexcept;
+
+} // namespace persist

--- a/src/persist/incident_spec.cpp
+++ b/src/persist/incident_spec.cpp
@@ -1,0 +1,465 @@
+#include "persist/incident_spec.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <fstream>
+#include <limits>
+
+namespace persist {
+namespace {
+
+class JsonCursor {
+public:
+    explicit JsonCursor(std::string_view s) : src_(s) {}
+
+    void skip_ws() const noexcept {
+        while (pos_ < src_.size() && std::isspace(static_cast<unsigned char>(src_[pos_]))) {
+            ++pos_;
+        }
+    }
+
+    bool consume(char c) noexcept {
+        skip_ws();
+        if (pos_ < src_.size() && src_[pos_] == c) {
+            ++pos_;
+            return true;
+        }
+        return false;
+    }
+
+    bool expect(char c) noexcept {
+        skip_ws();
+        if (pos_ >= src_.size() || src_[pos_] != c) {
+            return false;
+        }
+        ++pos_;
+        return true;
+    }
+
+    std::optional<std::string> parse_string(std::string& err) noexcept {
+        skip_ws();
+        if (pos_ >= src_.size() || src_[pos_] != '"') {
+            err = "Expected string";
+            return std::nullopt;
+        }
+        ++pos_; // skip opening quote
+        std::string out;
+        while (pos_ < src_.size()) {
+            const char c = src_[pos_++];
+            if (c == '"') {
+                return out;
+            }
+            if (c == '\\') {
+                if (pos_ >= src_.size()) {
+                    err = "Invalid escape";
+                    return std::nullopt;
+                }
+                const char esc = src_[pos_++];
+                switch (esc) {
+                    case '"': out.push_back('"'); break;
+                    case '\\': out.push_back('\\'); break;
+                    case '/': out.push_back('/'); break;
+                    case 'b': out.push_back('\b'); break;
+                    case 'f': out.push_back('\f'); break;
+                    case 'n': out.push_back('\n'); break;
+                    case 'r': out.push_back('\r'); break;
+                    case 't': out.push_back('\t'); break;
+                    default:
+                        err = "Unsupported escape sequence";
+                        return std::nullopt;
+                }
+            } else {
+                out.push_back(c);
+            }
+        }
+        err = "Unterminated string";
+        return std::nullopt;
+    }
+
+    std::optional<std::uint64_t> parse_uint64(std::string& err) noexcept {
+        skip_ws();
+        const std::size_t start = pos_;
+        while (pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_]))) {
+            ++pos_;
+        }
+        if (start == pos_) {
+            err = "Expected integer";
+            return std::nullopt;
+        }
+        std::uint64_t value = 0;
+        const auto* begin = src_.data() + start;
+        const auto* end = src_.data() + pos_;
+        const auto conv = std::from_chars(begin, end, value);
+        if (conv.ec != std::errc()) {
+            err = "Invalid integer";
+            return std::nullopt;
+        }
+        return value;
+    }
+
+    bool parse_literal(std::string_view literal, std::string& err) noexcept {
+        skip_ws();
+        if (src_.substr(pos_).compare(0, literal.size(), literal) == 0) {
+            pos_ += literal.size();
+            return true;
+        }
+        err = "Expected literal";
+        return false;
+    }
+
+    bool eof() const noexcept {
+        skip_ws();
+        return pos_ >= src_.size();
+    }
+
+private:
+    mutable std::size_t pos_{0};
+    std::string_view src_;
+};
+
+std::optional<core::OrderKey> hash_clordid(std::string_view text) noexcept {
+    // Same FNV-1a 64-bit hash as core::make_order_key.
+    static constexpr std::uint64_t fnv_offset_basis = 14695981039346656037ULL;
+    static constexpr std::uint64_t fnv_prime = 1099511628211ULL;
+
+    std::uint64_t hash = fnv_offset_basis;
+    for (char c : text) {
+        hash ^= static_cast<std::uint8_t>(c);
+        hash *= fnv_prime;
+    }
+    return hash;
+}
+
+} // namespace
+
+std::optional<core::DivergenceType> divergence_type_from_string(std::string_view s) noexcept {
+    if (s == "MissingFill") return core::DivergenceType::MissingFill;
+    if (s == "PhantomOrder") return core::DivergenceType::PhantomOrder;
+    if (s == "StateMismatch") return core::DivergenceType::StateMismatch;
+    if (s == "QuantityMismatch") return core::DivergenceType::QuantityMismatch;
+    if (s == "TimingAnomaly") return core::DivergenceType::TimingAnomaly;
+    return std::nullopt;
+}
+
+std::optional<core::OrderKey> parse_order_key_literal(std::string_view literal) noexcept {
+    if (literal.rfind("hash:", 0) == 0) {
+        std::uint64_t value = 0;
+        const auto numeric = literal.substr(5);
+        auto res = std::from_chars(numeric.data(), numeric.data() + numeric.size(), value);
+        if (res.ec == std::errc()) {
+            return value;
+        }
+        return std::nullopt;
+    }
+    if (literal.rfind("clordid:", 0) == 0) {
+        return hash_clordid(literal.substr(8));
+    }
+    // Backward-compatible alias: hash the entire literal.
+    return hash_clordid(literal);
+}
+
+bool wildcard_match(std::string_view pattern, std::string_view value) noexcept {
+    std::size_t p = 0, v = 0, star = std::string_view::npos, match = 0;
+    while (v < value.size()) {
+        if (p < pattern.size() &&
+            (pattern[p] == '?' || pattern[p] == value[v])) {
+            ++p; ++v;
+        } else if (p < pattern.size() && pattern[p] == '*') {
+            star = p++;
+            match = v;
+        } else if (star != std::string_view::npos) {
+            p = star + 1;
+            v = ++match;
+        } else {
+            return false;
+        }
+    }
+    while (p < pattern.size() && pattern[p] == '*') {
+        ++p;
+    }
+    return p == pattern.size();
+}
+
+static bool load_file(const std::filesystem::path& path, std::string& out, std::string& error) noexcept {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        error = "Failed to open file: " + path.string();
+        return false;
+    }
+    in.seekg(0, std::ios::end);
+    const auto len = in.tellg();
+    if (len < 0) {
+        error = "Failed to size file: " + path.string();
+        return false;
+    }
+    out.resize(static_cast<std::size_t>(len));
+    in.seekg(0, std::ios::beg);
+    if (!in.read(out.data(), out.size())) {
+        error = "Failed to read file: " + path.string();
+        return false;
+    }
+    return true;
+}
+
+bool parse_incident_spec(const std::filesystem::path& path,
+                         IncidentSpec& out,
+                         std::string& error) noexcept {
+    std::string contents;
+    if (!load_file(path, contents, error)) {
+        return false;
+    }
+    JsonCursor cur(contents);
+    if (!cur.expect('{')) {
+        error = "Expected object";
+        return false;
+    }
+    bool seen_id = false;
+    bool seen_desc = false;
+    bool seen_wire = false;
+    bool seen_replay = false;
+    IncidentSpec spec;
+    while (true) {
+        cur.skip_ws();
+        if (cur.consume('}')) {
+            break;
+        }
+        std::string key_err;
+        auto key = cur.parse_string(key_err);
+        if (!key) { error = key_err; return false; }
+        if (!cur.expect(':')) { error = "Expected ':'"; return false; }
+        if (*key == "id") {
+            auto val = cur.parse_string(key_err);
+            if (!val) { error = key_err; return false; }
+            spec.id = *val;
+            seen_id = true;
+        } else if (*key == "description") {
+            auto val = cur.parse_string(key_err);
+            if (!val) { error = key_err; return false; }
+            spec.description = *val;
+            seen_desc = true;
+        } else if (*key == "wire_inputs") {
+            if (!cur.expect('[')) { error = "Expected array"; return false; }
+            while (true) {
+                cur.skip_ws();
+                if (cur.consume(']')) { break; }
+                if (!cur.expect('{')) { error = "Expected object"; return false; }
+                IncidentWireInput wi;
+                bool pth=false, f=false, t=false;
+                while (true) {
+                    std::string kerr;
+                    auto wkey = cur.parse_string(kerr);
+                    if (!wkey) { error = kerr; return false; }
+                    if (!cur.expect(':')) { error = "Expected ':'"; return false; }
+                    if (*wkey == "path") {
+                        auto v = cur.parse_string(kerr);
+                        if (!v) { error = kerr; return false; }
+                        wi.path = *v;
+                        pth = true;
+                    } else if (*wkey == "from_ns") {
+                        auto v = cur.parse_uint64(kerr);
+                        if (!v) { error = kerr; return false; }
+                        wi.from_ns = *v;
+                        f = true;
+                    } else if (*wkey == "to_ns") {
+                        auto v = cur.parse_uint64(kerr);
+                        if (!v) { error = kerr; return false; }
+                        wi.to_ns = *v;
+                        t = true;
+                    } else {
+                        error = "Unknown wire_inputs field: " + *wkey;
+                        return false;
+                    }
+                    cur.skip_ws();
+                    if (cur.consume('}')) { break; }
+                    if (!cur.consume(',')) { error = "Expected ','"; return false; }
+                }
+                if (!(pth && f && t)) { error = "wire_inputs entry missing fields"; return false; }
+                spec.wire_inputs.push_back(wi);
+                cur.skip_ws();
+                if (cur.consume(']')) { break; }
+                if (!cur.consume(',')) { error = "Expected ','"; return false; }
+            }
+            seen_wire = true;
+        } else if (*key == "replay") {
+            if (!cur.expect('{')) { error = "Expected object"; return false; }
+            while (true) {
+                cur.skip_ws();
+                if (cur.consume('}')) break;
+                std::string rkerr;
+                auto rkey = cur.parse_string(rkerr);
+                if (!rkey) { error = rkerr; return false; }
+                if (!cur.expect(':')) { error = "Expected ':'"; return false; }
+                if (*rkey == "speed") {
+                    auto v = cur.parse_string(rkerr);
+                    if (!v) { error = rkerr; return false; }
+                    spec.replay.speed = *v;
+                } else if (*rkey == "max_records") {
+                    auto v = cur.parse_uint64(rkerr);
+                    if (!v) { error = rkerr; return false; }
+                    spec.replay.max_records = *v;
+                } else {
+                    error = "Unknown replay field: " + *rkey;
+                    return false;
+                }
+                cur.skip_ws();
+                if (cur.consume('}')) break;
+                if (!cur.consume(',')) { error = "Expected ','"; return false; }
+            }
+            seen_replay = true;
+        } else {
+            error = "Unknown field: " + *key;
+            return false;
+        }
+        cur.skip_ws();
+        if (cur.consume('}')) break;
+        if (!cur.consume(',')) { error = "Expected ','"; return false; }
+    }
+    if (!(seen_id && seen_desc && seen_wire && seen_replay)) {
+        error = "Missing required fields";
+        return false;
+    }
+    spec.replay.speed = spec.replay.speed.empty() ? "fast" : spec.replay.speed;
+    out = std::move(spec);
+    return true;
+}
+
+static bool parse_rules_array(JsonCursor& cur, Whitelist& wl, std::string& error) noexcept {
+    if (!cur.expect('[')) { error = "Expected rules array"; return false; }
+    while (true) {
+        cur.skip_ws();
+        if (cur.consume(']')) { break; }
+        if (!cur.expect('{')) { error = "Expected rule object"; return false; }
+        WhitelistRule rule;
+        bool have_type = false;
+        bool done = false;
+        while (!done) {
+            std::string kerr;
+            auto key = cur.parse_string(kerr);
+            if (!key) { error = kerr; return false; }
+            if (!cur.expect(':')) { error = "Expected ':'"; return false; }
+            if (*key == "type") {
+                auto v = cur.parse_string(kerr);
+                if (!v) { error = kerr; return false; }
+                if (*v == "ignore_divergence_type") {
+                    rule.type = WhitelistRuleType::IgnoreDivergenceType;
+                } else if (*v == "ignore_n_occurrences") {
+                    rule.type = WhitelistRuleType::IgnoreNOccurrences;
+                } else if (*v == "ignore_by_order_key") {
+                    rule.type = WhitelistRuleType::IgnoreByOrderKey;
+                } else if (*v == "allow_extra_files") {
+                    rule.type = WhitelistRuleType::AllowExtraFiles;
+                } else {
+                    error = "Unknown rule type: " + *v;
+                    return false;
+                }
+                have_type = true;
+            } else if (*key == "divergence_type") {
+                auto v = cur.parse_string(kerr);
+                if (!v) { error = kerr; return false; }
+                auto maybe = divergence_type_from_string(*v);
+                if (!maybe) { error = "Unknown divergence_type: " + *v; return false; }
+                rule.divergence_type = *maybe;
+            } else if (*key == "max_occurrences") {
+                auto v = cur.parse_uint64(kerr);
+                if (!v) { error = kerr; return false; }
+                rule.remaining_occurrences = static_cast<std::size_t>(*v);
+            } else if (*key == "order_keys") {
+                if (!cur.expect('[')) { error = "Expected order_keys array"; return false; }
+                while (true) {
+                    cur.skip_ws();
+                    if (cur.consume(']')) break;
+                    auto sv = cur.parse_string(kerr);
+                    if (!sv) { error = kerr; return false; }
+                    auto key_val = parse_order_key_literal(*sv);
+                    if (!key_val) { error = "Invalid order key literal: " + *sv; return false; }
+                    rule.order_keys.push_back(*key_val);
+                    cur.skip_ws();
+                    if (cur.consume(']')) break;
+                    if (!cur.consume(',')) { error = "Expected ','"; return false; }
+                }
+            } else if (*key == "patterns") {
+                if (!cur.expect('[')) { error = "Expected patterns array"; return false; }
+                while (true) {
+                    cur.skip_ws();
+                    if (cur.consume(']')) break;
+                    auto sv = cur.parse_string(kerr);
+                    if (!sv) { error = kerr; return false; }
+                    rule.patterns.push_back(*sv);
+                    cur.skip_ws();
+                    if (cur.consume(']')) break;
+                    if (!cur.consume(',')) { error = "Expected ','"; return false; }
+                }
+            } else if (*key == "reason") {
+                auto v = cur.parse_string(kerr);
+                if (!v) { error = kerr; return false; }
+                rule.reason = *v;
+            } else if (*key == "venue") {
+                auto v = cur.parse_string(kerr);
+                if (!v) { error = kerr; return false; }
+                rule.venue = *v;
+            } else {
+                error = "Unknown field in rule: " + *key;
+                return false;
+            }
+            cur.skip_ws();
+            if (cur.consume('}')) {
+                done = true;
+            } else if (!cur.consume(',')) {
+                error = "Expected ','";
+                return false;
+            }
+        }
+        if (!have_type) { error = "Rule missing type"; return false; }
+        wl.rules.push_back(std::move(rule));
+        cur.skip_ws();
+        if (cur.consume(']')) break;
+        if (!cur.consume(',')) { error = "Expected ','"; return false; }
+    }
+    return true;
+}
+
+bool parse_whitelist(const std::filesystem::path& path,
+                     Whitelist& out,
+                     std::string& error) noexcept {
+    std::string contents;
+    if (!load_file(path, contents, error)) {
+        return false;
+    }
+    JsonCursor cur(contents);
+    if (!cur.expect('{')) { error = "Expected object"; return false; }
+    Whitelist wl;
+    bool seen_version = false;
+    bool seen_rules = false;
+    while (true) {
+        cur.skip_ws();
+        if (cur.consume('}')) break;
+        std::string kerr;
+        auto key = cur.parse_string(kerr);
+        if (!key) { error = kerr; return false; }
+        if (!cur.expect(':')) { error = "Expected ':'"; return false; }
+        if (*key == "version") {
+            auto v = cur.parse_uint64(kerr);
+            if (!v) { error = kerr; return false; }
+            wl.version = static_cast<int>(*v);
+            seen_version = true;
+        } else if (*key == "rules") {
+            if (!parse_rules_array(cur, wl, error)) { return false; }
+            seen_rules = true;
+        } else {
+            error = "Unknown field: " + *key;
+            return false;
+        }
+        cur.skip_ws();
+        if (cur.consume('}')) break;
+        if (!cur.consume(',')) { error = "Expected ','"; return false; }
+    }
+    if (!seen_version || !seen_rules) {
+        error = "Missing version or rules";
+        return false;
+    }
+    out = std::move(wl);
+    return true;
+}
+
+} // namespace persist

--- a/src/persist/incident_spec.hpp
+++ b/src/persist/incident_spec.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "core/divergence.hpp"
+#include "core/order_state.hpp"
+
+namespace persist {
+
+struct IncidentWireInput {
+    std::filesystem::path path;
+    std::uint64_t from_ns{0};
+    std::uint64_t to_ns{0};
+};
+
+struct ReplayOptions {
+    std::string speed{"fast"};
+    std::uint64_t max_records{0};
+};
+
+struct IncidentSpec {
+    std::string id;
+    std::string description;
+    std::vector<IncidentWireInput> wire_inputs;
+    ReplayOptions replay;
+};
+
+enum class WhitelistRuleType {
+    IgnoreDivergenceType,
+    IgnoreNOccurrences,
+    IgnoreByOrderKey,
+    AllowExtraFiles
+};
+
+struct WhitelistRule {
+    WhitelistRuleType type{WhitelistRuleType::IgnoreDivergenceType};
+    // For IgnoreDivergenceType and IgnoreNOccurrences.
+    core::DivergenceType divergence_type{core::DivergenceType::StateMismatch};
+    std::size_t remaining_occurrences{0}; // Used only for IgnoreNOccurrences.
+    // For IgnoreByOrderKey.
+    std::vector<core::OrderKey> order_keys;
+    // For AllowExtraFiles.
+    std::vector<std::string> patterns;
+    // Optional venue label (ignored if not present in payload).
+    std::string venue;
+    std::string reason;
+};
+
+struct Whitelist {
+    int version{1};
+    std::vector<WhitelistRule> rules;
+
+    bool empty() const noexcept { return rules.empty(); }
+};
+
+// Parsing helpers. These functions are schema-specific and deterministic;
+// they avoid dynamic locale dependencies and do not throw.
+bool parse_incident_spec(const std::filesystem::path& path,
+                         IncidentSpec& out,
+                         std::string& error) noexcept;
+
+bool parse_whitelist(const std::filesystem::path& path,
+                     Whitelist& out,
+                     std::string& error) noexcept;
+
+// Shared helpers exposed for testing and reuse.
+std::optional<core::DivergenceType> divergence_type_from_string(std::string_view s) noexcept;
+
+// Hash an order key literal using the same FNV-1a algorithm as audit writer.
+// Accepts prefixes:
+//   - "hash:<uint64>" uses the numeric literal directly.
+//   - "clordid:<text>" hashes the text.
+//   - Legacy strings (e.g., "EBS:12345") are hashed as-is for compatibility.
+std::optional<core::OrderKey> parse_order_key_literal(std::string_view literal) noexcept;
+
+// Simple glob matcher supporting '*' and '?'.
+bool wildcard_match(std::string_view pattern, std::string_view value) noexcept;
+
+} // namespace persist

--- a/tests/audit_diff_tests.cpp
+++ b/tests/audit_diff_tests.cpp
@@ -1,0 +1,218 @@
+#include "persist/audit_diff.hpp"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <span>
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <psapi.h>
+#else
+#include <sys/resource.h>
+#endif
+
+#include "persist/audit_log_format.hpp"
+
+using namespace persist;
+
+namespace {
+
+std::filesystem::path make_temp_dir(const std::string& name) {
+    auto base = std::filesystem::temp_directory_path() / name;
+    std::error_code ec;
+    std::filesystem::remove_all(base, ec);
+    std::filesystem::create_directories(base);
+    return base;
+}
+
+std::vector<std::byte> make_divergence_record(core::OrderKey key, core::DivergenceType type) {
+    core::Divergence div{};
+    div.key = key;
+    div.type = type;
+    div.internal_status = core::OrdStatus::Working;
+    div.dropcopy_status = core::OrdStatus::Working;
+    div.internal_cum_qty = 1;
+    div.dropcopy_cum_qty = 2;
+    div.internal_avg_px = 3;
+    div.dropcopy_avg_px = 4;
+    div.internal_ts = 10;
+    div.dropcopy_ts = 11;
+
+    std::vector<std::byte> buf(record_size_from_payload(divergence_payload_v1_size));
+    std::size_t written = 0;
+    EXPECT_TRUE(encode_divergence_record_v1(div, buf, written));
+    buf.resize(written);
+    return buf;
+}
+
+void write_records(const std::filesystem::path& path,
+                   const std::vector<std::vector<std::byte>>& records) {
+    std::ofstream out(path, std::ios::binary);
+    ASSERT_TRUE(out.is_open());
+    for (const auto& rec : records) {
+        out.write(reinterpret_cast<const char*>(rec.data()),
+                  static_cast<std::streamsize>(rec.size()));
+    }
+}
+
+std::size_t current_rss_bytes() {
+#if defined(_WIN32)
+    PROCESS_MEMORY_COUNTERS counters{};
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &counters, sizeof(counters))) {
+        return static_cast<std::size_t>(counters.PeakWorkingSetSize);
+    }
+    return 0;
+#else
+    struct rusage usage {};
+    if (getrusage(RUSAGE_SELF, &usage) == 0) {
+        return static_cast<std::size_t>(usage.ru_maxrss) * 1024; // ru_maxrss in KB
+    }
+    return 0;
+#endif
+}
+
+} // namespace
+
+static void write_whitelist_file(const std::filesystem::path& path, const std::string& body) {
+    std::ofstream out(path);
+    ASSERT_TRUE(out.is_open());
+    out << body;
+}
+
+TEST(AuditDiffTests, ExactMatchDirectories) {
+    auto exp = make_temp_dir("audit_diff_exp1");
+    auto act = make_temp_dir("audit_diff_act1");
+    auto record = make_divergence_record(1, core::DivergenceType::StateMismatch);
+    write_records(exp / "audit.bin", {record});
+    write_records(act / "audit.bin", {record});
+
+    DiffStats stats;
+    DiffOptions options;
+    std::string report;
+    const auto result = diff_directories(exp, act, options, stats, report);
+    EXPECT_EQ(result, DiffResult::Match);
+    EXPECT_EQ(stats.mismatches, 0u);
+    EXPECT_EQ(stats.files_compared, 1u);
+}
+
+TEST(AuditDiffTests, SingleByteDiff) {
+    auto exp = make_temp_dir("audit_diff_exp2");
+    auto act = make_temp_dir("audit_diff_act2");
+    auto record = make_divergence_record(2, core::DivergenceType::StateMismatch);
+    auto record_diff = record;
+    record_diff[0] = std::byte{static_cast<unsigned char>(static_cast<uint8_t>(record_diff[0]) ^ 0xFF)};
+    write_records(exp / "audit.bin", {record});
+    write_records(act / "audit.bin", {record_diff});
+
+    DiffStats stats;
+    DiffOptions options;
+    std::string report;
+    const auto result = diff_directories(exp, act, options, stats, report);
+    EXPECT_EQ(result, DiffResult::Mismatch);
+    EXPECT_GT(stats.mismatches, 0u);
+    EXPECT_NE(report.find("Offset"), std::string::npos);
+}
+
+TEST(AuditDiffTests, WhitelistedDiff) {
+    auto exp = make_temp_dir("audit_diff_exp3");
+    auto act = make_temp_dir("audit_diff_act3");
+    auto record_exp = make_divergence_record(3, core::DivergenceType::StateMismatch);
+    auto record_act = make_divergence_record(3, core::DivergenceType::QuantityMismatch);
+    write_records(exp / "audit.bin", {record_exp});
+    write_records(act / "audit.bin", {record_act});
+
+    auto wl_dir = make_temp_dir("audit_diff_wl3");
+    auto whitelist_path = wl_dir / "whitelist.json";
+    write_whitelist_file(whitelist_path, R"({
+        "version": 1,
+        "rules": [
+            {"type":"ignore_divergence_type","divergence_type":"QuantityMismatch","reason":"test"}
+        ]
+    })");
+
+    DiffStats stats;
+    DiffOptions options;
+    options.byte_for_byte = false;
+    options.whitelist_path = whitelist_path;
+    std::string report;
+    const auto result = diff_directories(exp, act, options, stats, report);
+    EXPECT_EQ(result, DiffResult::Match) << report;
+    EXPECT_EQ(stats.mismatches, 0u) << report;
+    EXPECT_GT(stats.whitelisted, 0u);
+}
+
+TEST(AuditDiffTests, MissingExpectedFile) {
+    auto exp = make_temp_dir("audit_diff_exp4");
+    auto act = make_temp_dir("audit_diff_act4");
+    auto record = make_divergence_record(4, core::DivergenceType::StateMismatch);
+    write_records(act / "audit.bin", {record});
+
+    DiffStats stats;
+    DiffOptions options;
+    std::string report;
+    const auto result = diff_directories(exp, act, options, stats, report);
+    EXPECT_EQ(result, DiffResult::Mismatch);
+    EXPECT_GT(stats.mismatches, 0u);
+}
+
+TEST(AuditDiffTests, ExtraActualFileAllowed) {
+    auto exp = make_temp_dir("audit_diff_exp5");
+    auto act = make_temp_dir("audit_diff_act5");
+    auto record = make_divergence_record(5, core::DivergenceType::StateMismatch);
+    write_records(exp / "audit.bin", {record});
+    write_records(act / "audit.bin", {record});
+    write_records(act / "debug_tmp.bin", {record});
+
+    auto wl_dir = make_temp_dir("audit_diff_wl5");
+    auto whitelist_path = wl_dir / "whitelist.json";
+    write_whitelist_file(whitelist_path, R"({
+        "version": 1,
+        "rules": [
+            {"type":"allow_extra_files","patterns":["debug_*"],"reason":"allow debug"}
+        ]
+    })");
+
+    DiffStats stats;
+    DiffOptions options;
+    options.whitelist_path = whitelist_path;
+    std::string report;
+    const auto result = diff_directories(exp, act, options, stats, report);
+    EXPECT_EQ(result, DiffResult::Match) << report;
+    EXPECT_EQ(stats.mismatches, 0u) << report;
+    EXPECT_GT(stats.whitelisted, 0u);
+}
+
+TEST(AuditDiffTests, StreamingLargeFileMemoryBounded) {
+    auto exp = make_temp_dir("audit_diff_exp6");
+    auto act = make_temp_dir("audit_diff_act6");
+
+    const std::size_t record_size = record_size_from_payload(divergence_payload_v1_size);
+    const std::size_t target_bytes = 110ull * 1024ull * 1024ull;
+    const std::size_t num_records = target_bytes / record_size;
+
+    std::vector<std::byte> rec = make_divergence_record(6, core::DivergenceType::StateMismatch);
+    {
+        std::ofstream out_exp(exp / "audit.bin", std::ios::binary);
+        std::ofstream out_act(act / "audit.bin", std::ios::binary);
+        ASSERT_TRUE(out_exp.is_open());
+        ASSERT_TRUE(out_act.is_open());
+        for (std::size_t i = 0; i < num_records; ++i) {
+            out_exp.write(reinterpret_cast<const char*>(rec.data()), static_cast<std::streamsize>(rec.size()));
+            out_act.write(reinterpret_cast<const char*>(rec.data()), static_cast<std::streamsize>(rec.size()));
+        }
+    }
+
+    DiffStats stats;
+    DiffOptions options;
+    options.byte_for_byte = false; // Force record streaming path.
+    std::string report;
+    const auto result = diff_directories(exp, act, options, stats, report);
+    const auto after = current_rss_bytes();
+    ASSERT_EQ(result, DiffResult::Match);
+    EXPECT_EQ(stats.mismatches, 0u);
+    EXPECT_LT(after, 300ull * 1024ull * 1024ull);
+    EXPECT_GT(stats.records_compared, 0u);
+}


### PR DESCRIPTION
## Summary
- Document the incident specification workflow and include an example incident with spec and whitelist artifacts
- Add deterministic, schema-specific incident and whitelist parsers aligned with audit order-key hashing
- Implement streaming audit diffing with whitelist support, size guards, and regression tests including large file coverage

## Testing
- cmake --preset debug -DFX_ENABLE_AERON=OFF
- cmake --build --preset debug
- ctest --preset debug

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949477f962c8328aac0972369adc3eb)