### PR TITLE
Add incident runner regression harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,9 @@ add_library(fx_core
     src/persist/audit_log_writer.cpp
     src/persist/incident_spec.cpp
     src/persist/audit_diff.cpp
+    src/api/replay_engine.cpp
     src/api/replay.cpp
+    src/api/incident_runner_main.cpp
 )
 
 target_include_directories(fx_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -210,6 +212,11 @@ add_executable(fx_replay_main
 )
 target_link_libraries(fx_replay_main PRIVATE fx_core)
 
+add_executable(fx_incident_runner
+    src/api/incident_runner_entry.cpp
+)
+target_link_libraries(fx_incident_runner PRIVATE fx_core)
+
 set(TEST_SOURCES
     tests/ring_tests.cpp
     tests/fix_parser_tests.cpp
@@ -230,6 +237,7 @@ set(TEST_SOURCES
     tests/audit_log_integration_tests.cpp
     tests/replay_integration_tests.cpp
     tests/audit_diff_tests.cpp
+    tests/incident_runner_integration_test.cpp
 )
 if(FX_ENABLE_AERON)
   list(APPEND TEST_SOURCES tests/aeron_subscriber_tests.cpp)

--- a/incidents/README.md
+++ b/incidents/README.md
@@ -31,26 +31,41 @@ Incident specifications define deterministic replay inputs and expected outputs 
 - `replay.speed`: `"fast"` for unthrottled playback (default), `"realtime"` for paced playback.
 - `replay.max_records`: 0 means no limit.
 
-## Workflow
+## Adding an Incident
 
-1. **Generate golden outputs (run once):**
+1. Create directory: `incidents/<id>/`
+2. Add `incident.json` (see schema above)
+3. Add `baseline_config.json`
+4. Add `candidate_config.json`
+5. Optional: Add `whitelist.json`
 
-   ```bash
-   replay_main --incident incidents/<ID>/spec.json \
-               --config configs/baseline.json \
-               --output incidents/<ID>/golden
-   ```
+## Generating Golden Output
 
-2. **Test a candidate build (repeatable):**
+Use the regression harness to refresh golden outputs from the baseline configuration:
 
-   ```bash
-   replay_main --incident incidents/<ID>/spec.json \
-               --config configs/candidate.json \
-               --output /tmp/candidate
+```bash
+fx_incident_runner --spec incidents/<id>/incident.json --refresh-golden
+```
 
-   audit_diff incidents/<ID>/golden /tmp/candidate \
-              --whitelist incidents/<ID>/whitelist.json
-   ```
+## Running Regression Test
+
+```bash
+fx_incident_runner --spec incidents/<id>/incident.json
+```
+
+## CI Integration
+
+Example loop across all incidents:
+
+```bash
+for incident in incidents/*/incident.json; do
+    fx_incident_runner --spec "$incident" || exit $?
+done
+```
+
+## Whitelist Rules
+
+See `whitelist.json` schema in Part 1 documentation. A whitelist can be supplied explicitly with `--whitelist` or discovered automatically at `incidents/<id>/whitelist.json`.
 
 ## Whitelist (whitelist.json)
 

--- a/src/api/incident_runner.hpp
+++ b/src/api/incident_runner.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace incident_runner {
+
+// Run using argv-style inputs.
+int run_incident_runner_main(int argc, char** argv);
+
+// Convenience for tests / programmatic callers.
+int run_incident_runner_cli(const std::vector<std::string>& args);
+
+} // namespace incident_runner
+

--- a/src/api/incident_runner_entry.cpp
+++ b/src/api/incident_runner_entry.cpp
@@ -1,0 +1,6 @@
+#include "api/incident_runner.hpp"
+
+int main(int argc, char** argv) {
+    return incident_runner::run_incident_runner_main(argc, argv);
+}
+

--- a/src/api/incident_runner_main.cpp
+++ b/src/api/incident_runner_main.cpp
@@ -1,0 +1,843 @@
+#include <algorithm>
+#include <chrono>
+#include <charconv>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "api/incident_runner.hpp"
+#include "api/replay_engine.hpp"
+#include "persist/audit_diff.hpp"
+#include "persist/incident_spec.hpp"
+#include "util/crc32c.hpp"
+
+namespace {
+
+struct CliOptions {
+    std::filesystem::path spec_path;
+    bool refresh_golden{false};
+    bool keep_temp{false};
+    std::optional<std::filesystem::path> work_dir;
+    std::optional<std::filesystem::path> baseline_config;
+    std::optional<std::filesystem::path> candidate_config;
+    std::optional<std::filesystem::path> whitelist;
+    bool verbose{false};
+    bool quiet{false};
+};
+
+struct ParsedReplayConfig {
+    std::optional<std::size_t> max_records;
+    std::optional<std::string> speed;
+    std::string raw;
+    std::string hash_hex;
+};
+
+struct RunPaths {
+    std::filesystem::path work_root;
+    std::filesystem::path golden_dir;
+    std::filesystem::path golden_backup_dir;
+    std::filesystem::path candidate_root;
+    std::filesystem::path candidate_output_dir;
+    std::filesystem::path candidate_diff_report;
+    std::filesystem::path candidate_metadata;
+};
+
+constexpr int kExitSuccess = 0;
+constexpr int kExitMismatch = 2;
+constexpr int kExitSpecError = 3;
+constexpr int kExitIoError = 4;
+constexpr int kExitReplayError = 5;
+
+void print_usage(const char* prog) {
+    std::cerr << "Usage: " << prog << " --spec <path> [options]\n"
+              << "Options:\n"
+              << "  --refresh-golden           Regenerate golden from baseline\n"
+              << "  --keep-temp                Keep candidate output directories\n"
+              << "  --work-dir <path>          Override work directory (default incident_runs/<id>/)\n"
+              << "  --baseline-config <path>   Baseline config file\n"
+              << "  --candidate-config <path>  Candidate config file\n"
+              << "  --whitelist <path>         Whitelist JSON\n"
+              << "  --verbose                  Verbose logging\n"
+              << "  --quiet                    Quiet logging\n";
+}
+
+bool parse_cli(int argc, char** argv, CliOptions& out) {
+    if (argc < 3) {
+        print_usage(argv[0]);
+        return false;
+    }
+    CliOptions opts;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--spec" && i + 1 < argc) {
+            opts.spec_path = argv[++i];
+        } else if (arg == "--refresh-golden") {
+            opts.refresh_golden = true;
+        } else if (arg == "--keep-temp") {
+            opts.keep_temp = true;
+        } else if (arg == "--work-dir" && i + 1 < argc) {
+            opts.work_dir = std::filesystem::path(argv[++i]);
+        } else if (arg == "--baseline-config" && i + 1 < argc) {
+            opts.baseline_config = std::filesystem::path(argv[++i]);
+        } else if (arg == "--candidate-config" && i + 1 < argc) {
+            opts.candidate_config = std::filesystem::path(argv[++i]);
+        } else if (arg == "--whitelist" && i + 1 < argc) {
+            opts.whitelist = std::filesystem::path(argv[++i]);
+        } else if (arg == "--verbose") {
+            opts.verbose = true;
+        } else if (arg == "--quiet") {
+            opts.quiet = true;
+        } else {
+            print_usage(argv[0]);
+            return false;
+        }
+    }
+    out = std::move(opts);
+    return true;
+}
+
+std::string format_error(int code, std::string_view description, std::string_view details, std::string_view action) {
+    std::ostringstream oss;
+    oss << "Exit " << code << ": " << description << "\n"
+        << "Details: " << details << "\n"
+        << "Action: " << action;
+    return oss.str();
+}
+
+bool read_file(const std::filesystem::path& path, std::string& out, std::string& err) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in.is_open()) {
+        err = "Failed to open file: " + path.string();
+        return false;
+    }
+    in.seekg(0, std::ios::end);
+    const auto len = in.tellg();
+    if (len < 0) {
+        err = "Failed to size file: " + path.string();
+        return false;
+    }
+    out.resize(static_cast<std::size_t>(len));
+    in.seekg(0, std::ios::beg);
+    if (!in.read(out.data(), out.size())) {
+        err = "Failed to read file: " + path.string();
+        return false;
+    }
+    return true;
+}
+
+std::string crc32_hex(std::string_view data) {
+    const auto crc = util::Crc32c::compute(reinterpret_cast<const std::byte*>(data.data()), data.size());
+    std::ostringstream oss;
+    oss << std::hex << std::uppercase;
+    oss.width(8);
+    oss.fill('0');
+    oss << crc;
+    return oss.str();
+}
+
+class JsonCursor {
+public:
+    explicit JsonCursor(std::string_view src) : src_(src) {}
+
+    void skip_ws() const noexcept {
+        while (pos_ < src_.size() && std::isspace(static_cast<unsigned char>(src_[pos_]))) {
+            ++pos_;
+        }
+    }
+
+    bool consume(char c) noexcept {
+        skip_ws();
+        if (pos_ < src_.size() && src_[pos_] == c) {
+            ++pos_;
+            return true;
+        }
+        return false;
+    }
+
+    bool expect(char c) noexcept {
+        skip_ws();
+        if (pos_ >= src_.size() || src_[pos_] != c) {
+            return false;
+        }
+        ++pos_;
+        return true;
+    }
+
+    std::optional<std::string> parse_string(std::string& err) noexcept {
+        skip_ws();
+        if (pos_ >= src_.size() || src_[pos_] != '"') {
+            err = "Expected string";
+            return std::nullopt;
+        }
+        ++pos_;
+        std::string out;
+        while (pos_ < src_.size()) {
+            const char c = src_[pos_++];
+            if (c == '"') {
+                return out;
+            }
+            if (c == '\\') {
+                if (pos_ >= src_.size()) {
+                    err = "Invalid escape";
+                    return std::nullopt;
+                }
+                const char esc = src_[pos_++];
+                switch (esc) {
+                case '"': out.push_back('"'); break;
+                case '\\': out.push_back('\\'); break;
+                case '/': out.push_back('/'); break;
+                case 'b': out.push_back('\b'); break;
+                case 'f': out.push_back('\f'); break;
+                case 'n': out.push_back('\n'); break;
+                case 'r': out.push_back('\r'); break;
+                case 't': out.push_back('\t'); break;
+                default:
+                    err = "Unsupported escape sequence";
+                    return std::nullopt;
+                }
+            } else {
+                out.push_back(c);
+            }
+        }
+        err = "Unterminated string";
+        return std::nullopt;
+    }
+
+    std::optional<std::uint64_t> parse_uint64(std::string& err) noexcept {
+        skip_ws();
+        const std::size_t start = pos_;
+        while (pos_ < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_]))) {
+            ++pos_;
+        }
+        if (start == pos_) {
+            err = "Expected integer";
+            return std::nullopt;
+        }
+        std::uint64_t value = 0;
+        const auto* begin = src_.data() + start;
+        const auto* end = src_.data() + pos_;
+        const auto conv = std::from_chars(begin, end, value);
+        if (conv.ec != std::errc()) {
+            err = "Invalid integer";
+            return std::nullopt;
+        }
+        return value;
+    }
+
+    bool skip_value(std::string& err) noexcept {
+        skip_ws();
+        if (pos_ >= src_.size()) {
+            err = "Unexpected end of input";
+            return false;
+        }
+        const char c = src_[pos_];
+        if (c == '"') {
+            auto str = parse_string(err);
+            return str.has_value();
+        }
+        if (std::isdigit(static_cast<unsigned char>(c)) || c == '-') {
+            // rudimentary number skip
+            ++pos_;
+            while (pos_ < src_.size() && (std::isdigit(static_cast<unsigned char>(src_[pos_])) || src_[pos_] == '.')) {
+                ++pos_;
+            }
+            return true;
+        }
+        if (c == '{') {
+            ++pos_;
+            int depth = 1;
+            while (pos_ < src_.size() && depth > 0) {
+                if (src_[pos_] == '{') ++depth;
+                else if (src_[pos_] == '}') --depth;
+                ++pos_;
+            }
+            if (depth != 0) {
+                err = "Unterminated object";
+                return false;
+            }
+            return true;
+        }
+        if (c == '[') {
+            ++pos_;
+            int depth = 1;
+            while (pos_ < src_.size() && depth > 0) {
+                if (src_[pos_] == '[') ++depth;
+                else if (src_[pos_] == ']') --depth;
+                ++pos_;
+            }
+            if (depth != 0) {
+                err = "Unterminated array";
+                return false;
+            }
+            return true;
+        }
+        if (src_.substr(pos_).rfind("true", 0) == 0) { pos_ += 4; return true; }
+        if (src_.substr(pos_).rfind("false", 0) == 0) { pos_ += 5; return true; }
+        if (src_.substr(pos_).rfind("null", 0) == 0) { pos_ += 4; return true; }
+        err = "Unexpected token";
+        return false;
+    }
+
+private:
+    mutable std::size_t pos_{0};
+    std::string_view src_;
+};
+
+bool parse_replay_config_file(const std::filesystem::path& path, ParsedReplayConfig& out, std::string& err) {
+    ParsedReplayConfig parsed{};
+    if (!read_file(path, parsed.raw, err)) {
+        return false;
+    }
+    parsed.hash_hex = crc32_hex(parsed.raw);
+
+    JsonCursor cur(parsed.raw);
+    if (!cur.expect('{')) {
+        err = "Expected object";
+        return false;
+    }
+    while (true) {
+        cur.skip_ws();
+        if (cur.consume('}')) {
+            break;
+        }
+        std::string key_err;
+        auto key = cur.parse_string(key_err);
+        if (!key) { err = key_err; return false; }
+        if (!cur.expect(':')) { err = "Expected ':'"; return false; }
+        if (*key == "max_records") {
+            auto v = cur.parse_uint64(key_err);
+            if (!v) { err = key_err; return false; }
+            parsed.max_records = static_cast<std::size_t>(*v);
+        } else if (*key == "speed") {
+            auto v = cur.parse_string(key_err);
+            if (!v) { err = key_err; return false; }
+            parsed.speed = *v;
+        } else {
+            if (!cur.skip_value(key_err)) { err = key_err; return false; }
+        }
+        cur.skip_ws();
+        if (cur.consume('}')) {
+            break;
+        }
+        if (!cur.consume(',')) { err = "Expected ','"; return false; }
+    }
+    out = std::move(parsed);
+    return true;
+}
+
+std::string timestamp_label() {
+    const auto now = std::chrono::system_clock::now();
+    const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(now);
+    const auto value = secs.time_since_epoch().count();
+    std::ostringstream oss;
+    oss << value;
+    return oss.str();
+}
+
+RunPaths build_paths(const persist::IncidentSpec& spec, const CliOptions& cli) {
+    RunPaths paths{};
+    const auto base = cli.work_dir.value_or(std::filesystem::path("incident_runs") / spec.id);
+    paths.work_root = base;
+    paths.golden_dir = base / "golden";
+    const std::string stamp = cli.work_dir ? std::string("fixed") : timestamp_label();
+    const std::string run_dir = cli.work_dir ? std::string("run") : ("run_" + stamp);
+    paths.candidate_root = base / run_dir;
+    paths.candidate_output_dir = paths.candidate_root / "candidate";
+    paths.candidate_diff_report = paths.candidate_root / "diff_report.txt";
+    paths.candidate_metadata = paths.candidate_root / "metadata.json";
+    paths.golden_backup_dir = cli.work_dir ? (base / "golden.backup") : (base / ("golden.backup." + stamp));
+    return paths;
+}
+
+std::filesystem::path default_baseline_config(const persist::IncidentSpec& spec) {
+    return std::filesystem::path("incidents") / spec.id / "baseline_config.json";
+}
+
+std::filesystem::path default_candidate_config(const persist::IncidentSpec& spec) {
+    return std::filesystem::path("incidents") / spec.id / "candidate_config.json";
+}
+
+std::filesystem::path default_whitelist(const persist::IncidentSpec& spec) {
+    return std::filesystem::path("incidents") / spec.id / "whitelist.json";
+}
+
+bool ensure_empty_dir(const std::filesystem::path& dir, std::string& err) {
+    std::error_code ec;
+    if (std::filesystem::exists(dir, ec)) {
+        std::filesystem::remove_all(dir, ec);
+        if (ec) {
+            err = "Failed to clear directory: " + dir.string() + " (" + ec.message() + ")";
+            return false;
+        }
+    }
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        err = "Failed to create directory: " + dir.string() + " (" + ec.message() + ")";
+        return false;
+    }
+    return true;
+}
+
+bool copy_dir(const std::filesystem::path& from, const std::filesystem::path& to, std::string& err) {
+    std::error_code ec;
+    std::filesystem::create_directories(to, ec);
+    if (ec) {
+        err = "Failed to create directory: " + to.string() + " (" + ec.message() + ")";
+        return false;
+    }
+    for (auto it = std::filesystem::recursive_directory_iterator(from, ec);
+         !ec && it != std::filesystem::recursive_directory_iterator(); ++it) {
+        if (!it->is_regular_file()) {
+            continue;
+        }
+        const auto rel = std::filesystem::relative(it->path(), from, ec).lexically_normal();
+        if (ec) {
+            err = "Failed to compute relative path from " + it->path().string();
+            return false;
+        }
+        const auto dest = to / rel;
+        std::filesystem::create_directories(dest.parent_path(), ec);
+        if (ec) {
+            err = "Failed to create directory: " + dest.parent_path().string();
+            return false;
+        }
+        std::filesystem::copy_file(it->path(), dest, std::filesystem::copy_options::overwrite_existing, ec);
+        if (ec) {
+            err = "Failed to copy file " + it->path().string() + ": " + ec.message();
+            return false;
+        }
+    }
+    return true;
+}
+
+bool write_metadata(const std::filesystem::path& path,
+                    const persist::IncidentSpec& spec,
+                    const std::filesystem::path& config_path,
+                    const ParsedReplayConfig& cfg,
+                    const replay_engine::ReplayConfig& replay_cfg,
+                    std::string& err) {
+    std::ostringstream oss;
+    const auto now = std::chrono::system_clock::now();
+    const auto ts = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+    oss << "{\n"
+        << "  \"incident_id\": \"" << spec.id << "\",\n"
+        << "  \"config_path\": \"" << config_path.string() << "\",\n"
+        << "  \"config_hash_crc32c\": \"" << cfg.hash_hex << "\",\n"
+        << "  \"replay\": {\n"
+        << "    \"speed\": \"" << replay_cfg.speed << "\",\n"
+        << "    \"max_records\": " << replay_cfg.max_records << "\n"
+        << "  },\n"
+        << "  \"timestamp_ns\": " << ts << "\n"
+        << "}\n";
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        err = "Failed to write metadata: " + path.string();
+        return false;
+    }
+    out << oss.str();
+    if (!out) {
+        err = "Failed to write metadata: " + path.string();
+        return false;
+    }
+    return true;
+}
+
+std::filesystem::path resolve_relative(const std::filesystem::path& base_dir,
+                                       const std::filesystem::path& p) {
+    if (p.is_absolute()) {
+        return p;
+    }
+    return (base_dir / p).lexically_normal();
+}
+
+std::vector<std::filesystem::path> resolve_wire_inputs(const persist::IncidentSpec& spec,
+                                                       const std::filesystem::path& spec_dir) {
+    std::vector<std::filesystem::path> out;
+    for (const auto& wi : spec.wire_inputs) {
+        out.push_back(resolve_relative(spec_dir, wi.path));
+    }
+    return out;
+}
+
+std::optional<replay_engine::ReplayConfig> build_replay_config(const persist::IncidentSpec& spec,
+                                                               const ParsedReplayConfig& parsed_cfg,
+                                                               const std::vector<std::filesystem::path>& inputs,
+                                                               const std::filesystem::path& output_dir,
+                                                               const std::filesystem::path& config_path,
+                                                               std::string& err) {
+    replay_engine::ReplayConfig cfg;
+    cfg.wire_inputs = inputs;
+    cfg.output_dir = output_dir;
+    cfg.config_path = config_path;
+    cfg.speed = parsed_cfg.speed.value_or(spec.replay.speed.empty() ? std::string("fast") : spec.replay.speed);
+    cfg.max_records = parsed_cfg.max_records.value_or(spec.replay.max_records);
+    if (!spec.wire_inputs.empty()) {
+        std::uint64_t min_from = spec.wire_inputs.front().from_ns;
+        std::uint64_t max_to = spec.wire_inputs.front().to_ns;
+        for (const auto& wi : spec.wire_inputs) {
+            min_from = std::min(min_from, wi.from_ns);
+            max_to = std::max(max_to, wi.to_ns);
+        }
+        cfg.from_ns = min_from;
+        cfg.to_ns = max_to;
+    }
+    if (cfg.max_records > std::numeric_limits<std::size_t>::max()) {
+        err = "max_records exceeds size_t";
+        return std::nullopt;
+    }
+    return cfg;
+}
+
+bool backup_golden(const std::filesystem::path& src, const std::filesystem::path& dst, std::string& err) {
+    std::error_code ec;
+    if (!std::filesystem::exists(src, ec)) {
+        return true;
+    }
+    std::filesystem::remove_all(dst, ec);
+    if (ec) {
+        err = "Failed to clear golden backup: " + dst.string() + " (" + ec.message() + ")";
+        return false;
+    }
+    return copy_dir(src, dst, err);
+}
+
+bool filter_directory_without_metadata(const std::filesystem::path& source,
+                                       const std::filesystem::path& dest,
+                                       std::string& err) {
+    std::error_code ec;
+    std::filesystem::create_directories(dest, ec);
+    if (ec) {
+        err = "Failed to create directory: " + dest.string() + " (" + ec.message() + ")";
+        return false;
+    }
+    for (auto it = std::filesystem::recursive_directory_iterator(source, ec);
+         !ec && it != std::filesystem::recursive_directory_iterator(); ++it) {
+        if (!it->is_regular_file()) {
+            continue;
+        }
+        if (it->path().filename() == "metadata.json") {
+            continue;
+        }
+        const auto rel = std::filesystem::relative(it->path(), source, ec).lexically_normal();
+        if (ec) {
+            err = "Failed to compute relative path from " + it->path().string();
+            return false;
+        }
+        const auto dest_path = dest / rel;
+        std::filesystem::create_directories(dest_path.parent_path(), ec);
+        if (ec) {
+            err = "Failed to create directory: " + dest_path.parent_path().string();
+            return false;
+        }
+        std::filesystem::copy_file(it->path(), dest_path, std::filesystem::copy_options::overwrite_existing, ec);
+        if (ec) {
+            err = "Failed to copy file " + it->path().string() + ": " + ec.message();
+            return false;
+        }
+    }
+    return true;
+}
+
+int run_incident_runner(const CliOptions& cli) {
+    if (cli.spec_path.empty()) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Missing --spec",
+                                  "No incident spec provided",
+                                  "Invoke with --spec <path>") << std::endl;
+        return kExitSpecError;
+    }
+
+    persist::IncidentSpec spec;
+    std::string parse_err;
+    if (!persist::parse_incident_spec(cli.spec_path, spec, parse_err)) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Invalid incident spec",
+                                  parse_err,
+                                  "Fix the incident spec JSON and retry") << std::endl;
+        return kExitSpecError;
+    }
+
+    const auto spec_dir = cli.spec_path.parent_path();
+    const auto paths = build_paths(spec, cli);
+
+    const auto baseline_cfg_path = cli.baseline_config.value_or(default_baseline_config(spec));
+    const auto candidate_cfg_path = cli.candidate_config.value_or(default_candidate_config(spec));
+
+    if (!std::filesystem::exists(baseline_cfg_path)) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Config file not found",
+                                  baseline_cfg_path.string() + " does not exist",
+                                  "Create config file or use --baseline-config flag") << std::endl;
+        return kExitSpecError;
+    }
+    if (!std::filesystem::exists(candidate_cfg_path)) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Config file not found",
+                                  candidate_cfg_path.string() + " does not exist",
+                                  "Create config file or use --candidate-config flag") << std::endl;
+        return kExitSpecError;
+    }
+
+    std::optional<std::filesystem::path> whitelist_path;
+    if (cli.whitelist) {
+        whitelist_path = *cli.whitelist;
+    } else {
+        const auto default_wl = default_whitelist(spec);
+        if (std::filesystem::exists(default_wl)) {
+            whitelist_path = default_wl;
+        }
+    }
+    if (whitelist_path && !std::filesystem::exists(*whitelist_path)) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Whitelist file not found",
+                                  whitelist_path->string() + " does not exist",
+                                  "Provide a valid whitelist path or omit --whitelist") << std::endl;
+        return kExitSpecError;
+    }
+
+    ParsedReplayConfig baseline_cfg;
+    if (!parse_replay_config_file(baseline_cfg_path, baseline_cfg, parse_err)) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Invalid config file",
+                                  parse_err,
+                                  "Fix config JSON or provide a valid file") << std::endl;
+        return kExitSpecError;
+    }
+    ParsedReplayConfig candidate_cfg;
+    if (!parse_replay_config_file(candidate_cfg_path, candidate_cfg, parse_err)) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Invalid config file",
+                                  parse_err,
+                                  "Fix config JSON or provide a valid file") << std::endl;
+        return kExitSpecError;
+    }
+
+    std::vector<std::filesystem::path> wire_inputs = resolve_wire_inputs(spec, spec_dir);
+    for (const auto& p : wire_inputs) {
+        if (!std::filesystem::exists(p)) {
+            std::cerr << format_error(kExitIoError,
+                                      "Wire input missing",
+                                      p.string() + " does not exist",
+                                      "Provide the wire log file at the expected location") << std::endl;
+            return kExitIoError;
+        }
+    }
+
+    std::string err;
+    std::error_code exists_ec;
+    if (!std::filesystem::exists(paths.work_root, exists_ec)) {
+        std::error_code ec;
+        std::filesystem::create_directories(paths.work_root, ec);
+        if (ec) {
+            std::cerr << format_error(kExitIoError,
+                                      "Cannot create work directory",
+                                      ec.message(),
+                                      "Check permissions or free space") << std::endl;
+            return kExitIoError;
+        }
+    } else if (exists_ec) {
+        std::cerr << format_error(kExitIoError,
+                                  "Cannot stat work directory",
+                                  exists_ec.message(),
+                                  "Check permissions or free space") << std::endl;
+        return kExitIoError;
+    }
+
+    const bool golden_exists = std::filesystem::exists(paths.golden_dir);
+    if (!golden_exists && !cli.refresh_golden) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Golden output missing",
+                                  paths.golden_dir.string() + " does not exist",
+                                  "Re-run with --refresh-golden to create golden outputs") << std::endl;
+        return kExitSpecError;
+    }
+
+    if (cli.refresh_golden) {
+        if (!backup_golden(paths.golden_dir, paths.golden_backup_dir, err)) {
+            std::cerr << format_error(kExitIoError,
+                                      "Failed to backup golden",
+                                      err,
+                                      "Ensure disk space and permissions, then retry") << std::endl;
+            return kExitIoError;
+        }
+        if (!ensure_empty_dir(paths.golden_dir, err)) {
+            std::cerr << format_error(kExitIoError,
+                                      "Failed to prepare golden directory",
+                                      err,
+                                      "Check permissions and disk space") << std::endl;
+            return kExitIoError;
+        }
+        auto replay_cfg = build_replay_config(spec, baseline_cfg, wire_inputs, paths.golden_dir, baseline_cfg_path, err);
+        if (!replay_cfg) {
+            std::cerr << format_error(kExitSpecError,
+                                      "Invalid replay configuration",
+                                      err,
+                                      "Check speed and max_records values") << std::endl;
+            return kExitSpecError;
+        }
+        std::string replay_err;
+        auto res = replay_engine::run_replay(*replay_cfg, replay_err);
+        if (res != replay_engine::ReplayResult::Success) {
+            const int code = (res == replay_engine::ReplayResult::WireReadError) ? kExitIoError :
+                             (res == replay_engine::ReplayResult::ConfigError ? kExitSpecError :
+                             (res == replay_engine::ReplayResult::OutputError ? kExitIoError : kExitReplayError));
+            std::cerr << format_error(code,
+                                      "Baseline replay failed",
+                                      replay_err,
+                                      "Fix the baseline config or inputs and retry") << std::endl;
+            return code;
+        }
+        if (!write_metadata(paths.golden_dir / "metadata.json", spec, baseline_cfg_path, baseline_cfg, *replay_cfg, err)) {
+            std::cerr << format_error(kExitIoError,
+                                      "Failed to write golden metadata",
+                                      err,
+                                      "Check permissions and disk space") << std::endl;
+            return kExitIoError;
+        }
+    }
+
+    if (!ensure_empty_dir(paths.candidate_root, err)) {
+        std::cerr << format_error(kExitIoError,
+                                  "Failed to prepare candidate directory",
+                                  err,
+                                  "Check permissions and disk space") << std::endl;
+        return kExitIoError;
+    }
+    auto cand_cfg = build_replay_config(spec, candidate_cfg, wire_inputs, paths.candidate_output_dir, candidate_cfg_path, err);
+    if (!cand_cfg) {
+        std::cerr << format_error(kExitSpecError,
+                                  "Invalid replay configuration",
+                                  err,
+                                  "Check speed and max_records values") << std::endl;
+        return kExitSpecError;
+    }
+    std::string replay_err;
+    auto cand_res = replay_engine::run_replay(*cand_cfg, replay_err);
+    if (cand_res != replay_engine::ReplayResult::Success) {
+        const int code = (cand_res == replay_engine::ReplayResult::WireReadError) ? kExitIoError :
+                         (cand_res == replay_engine::ReplayResult::ConfigError ? kExitSpecError :
+                         (cand_res == replay_engine::ReplayResult::OutputError ? kExitIoError : kExitReplayError));
+        std::cerr << format_error(code,
+                                  "Candidate replay failed",
+                                  replay_err,
+                                  "Fix the candidate config or inputs and retry") << std::endl;
+        return code;
+    }
+    if (!write_metadata(paths.candidate_metadata, spec, candidate_cfg_path, candidate_cfg, *cand_cfg, err)) {
+        std::cerr << format_error(kExitIoError,
+                                  "Failed to write candidate metadata",
+                                  err,
+                                  "Check permissions and disk space") << std::endl;
+        return kExitIoError;
+    }
+
+    std::filesystem::path expected = paths.golden_dir;
+    std::filesystem::path actual = paths.candidate_output_dir;
+    const auto compare_root = paths.candidate_root / "compare";
+    const auto filtered_expected = compare_root / "expected";
+    const auto filtered_actual = compare_root / "actual";
+    if (!filter_directory_without_metadata(paths.golden_dir, filtered_expected, err) ||
+        !filter_directory_without_metadata(paths.candidate_output_dir, filtered_actual, err)) {
+        std::cerr << format_error(kExitIoError,
+                                  "Failed to prepare comparison directories",
+                                  err,
+                                  "Check permissions and disk space") << std::endl;
+        return kExitIoError;
+    }
+    expected = filtered_expected;
+    actual = filtered_actual;
+
+    persist::DiffOptions diff_opts;
+    diff_opts.byte_for_byte = true;
+    if (whitelist_path) {
+        diff_opts.whitelist_path = *whitelist_path;
+    } else {
+        diff_opts.allow_whitelist = false;
+    }
+    persist::DiffStats stats{};
+    std::string diff_report;
+    auto diff_res = persist::diff_directories(expected, actual, diff_opts, stats, diff_report);
+    if (!diff_report.empty()) {
+        std::ofstream out(paths.candidate_diff_report, std::ios::binary | std::ios::trunc);
+        if (out.is_open()) {
+            out << diff_report;
+        }
+    }
+
+    const bool refreshing = cli.refresh_golden;
+
+    switch (diff_res) {
+    case persist::DiffResult::Match:
+        if (!cli.keep_temp && !cli.work_dir) {
+            std::error_code ec;
+            std::filesystem::remove_all(paths.candidate_root, ec);
+        }
+        return kExitSuccess;
+    case persist::DiffResult::Mismatch:
+        if (refreshing) {
+            return kExitSuccess;
+        }
+        std::cerr << format_error(kExitMismatch,
+                                  "Candidate differs from golden",
+                                  "See diff_report.txt for details",
+                                  "Review changes or update whitelist") << std::endl;
+        return kExitMismatch;
+    case persist::DiffResult::BadWhitelist:
+        std::cerr << format_error(kExitSpecError,
+                                  "Invalid whitelist",
+                                  "Failed to parse whitelist file",
+                                  "Fix whitelist JSON") << std::endl;
+        return kExitSpecError;
+    case persist::DiffResult::BadFormat:
+        std::cerr << format_error(kExitSpecError,
+                                  "Audit format error",
+                                  "Unexpected audit log structure",
+                                  "Regenerate golden outputs") << std::endl;
+        return kExitSpecError;
+    case persist::DiffResult::IoError:
+        std::cerr << format_error(kExitIoError,
+                                  "I/O error during comparison",
+                                  "Failed to read output directories",
+                                  "Check permissions and disk space") << std::endl;
+        return kExitIoError;
+    }
+
+    return kExitReplayError;
+}
+
+} // namespace
+
+namespace incident_runner {
+int run_incident_runner_cli(const std::vector<std::string>& args) {
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    argv.push_back(const_cast<char*>("fx_incident_runner"));
+    for (const auto& a : args) {
+        argv.push_back(const_cast<char*>(a.c_str()));
+    }
+    CliOptions cli;
+    if (!parse_cli(static_cast<int>(argv.size()), argv.data(), cli)) {
+        return kExitSpecError;
+    }
+    return run_incident_runner(cli);
+}
+
+int run_incident_runner_main(int argc, char** argv) {
+    CliOptions cli;
+    if (!parse_cli(argc, argv, cli)) {
+        return kExitSpecError;
+    }
+    return run_incident_runner(cli);
+}
+} // namespace incident_runner

--- a/src/api/replay.cpp
+++ b/src/api/replay.cpp
@@ -1,77 +1,37 @@
 #include "api/replay.hpp"
 
 #include <algorithm>
-#include <atomic>
-#include <chrono>
-#include <cstddef>
-#include <cstdint>
 #include <array>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <iterator>
-#include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
-#include <thread>
 #include <vector>
 
-#include "core/exec_event.hpp"
-#include "core/order_state_store.hpp"
-#include "core/reconciler.hpp"
-#include "ingest/spsc_ring.hpp"
-#include "persist/audit_log_writer.hpp"
-#include "persist/wire_log_reader.hpp"
-#include "util/arena.hpp"
+#include "api/replay_engine.hpp"
+#include "persist/wire_log_format.hpp"
+#include "persist/wire_log_scan.hpp"
 #include "util/log.hpp"
-
-namespace api {
 
 namespace {
 
-using ExecRing = ingest::SpscRing<core::ExecEvent, 1u << 16>;
-
-struct ReplayLoopStats {
-    std::size_t processed_ok{0};
-    std::size_t read_errors{0};
-    std::size_t corrupt_records{0};
-    std::size_t push_failures{0};
-    std::size_t skipped_due_to_limit{0};
-    std::size_t backward_timestamps{0};
-};
-
-struct ReplayState {
-    std::atomic<bool> stop_flag{false};
-    std::atomic<bool> producer_done{false};
-    std::unique_ptr<ExecRing> primary_ring;
-    std::unique_ptr<ExecRing> dropcopy_ring;
-    std::unique_ptr<core::DivergenceRing> divergence_ring;
-    std::unique_ptr<core::SequenceGapRing> gap_ring;
-    persist::AuditLogCounters audit_counters;
-    core::ReconCounters recon_counters;
-};
-
-core::Source source_from_wire(const core::WireExecEvent& evt) noexcept {
-    // Derive source deterministically from session_id parity to avoid
-    // additional metadata in the wire log. Session ids used during capture
-    // should therefore be stable to preserve determinism.
-    return (evt.session_id % 2u == 0) ? core::Source::Primary : core::Source::DropCopy;
+std::vector<std::filesystem::path> gather_input_files(const api::ReplayConfig& cfg) {
+    if (!cfg.input_directory.empty()) {
+        return persist::scan_wire_logs(cfg.input_directory, persist::default_filename_prefix());
+    }
+    return cfg.input_files;
 }
 
-bool ensure_output_dir(const std::filesystem::path& p) {
-    std::error_code ec;
-    std::filesystem::create_directories(p, ec);
-    return !ec;
-}
-
-void log_if(bool enabled, util::LogLevel lvl, const char* fmt, const char* arg0 = nullptr) {
-    if (!enabled) {
-        return;
+std::string speed_to_string(const api::ReplayConfig& cfg) {
+    if (cfg.fast) {
+        return "fast";
     }
-    if (arg0) {
-        util::log(lvl, fmt, arg0);
-    } else {
-        util::log(lvl, "%s", fmt);
-    }
+    std::ostringstream oss;
+    oss.setf(std::ios::fixed);
+    oss << cfg.speed;
+    return oss.str();
 }
 
 struct CompareResult {
@@ -133,7 +93,7 @@ CompareResult compare_directories(const std::filesystem::path& lhs, const std::f
     std::vector<std::filesystem::path> right_files;
     auto collect = [](const std::filesystem::path& dir, std::vector<std::filesystem::path>& out) {
         std::error_code ec;
-        for (std::filesystem::directory_iterator it(dir, ec); !ec && it != std::filesystem::directory_iterator(); ++it) {
+        for (std::filesystem::recursive_directory_iterator it(dir, ec); !ec && it != std::filesystem::recursive_directory_iterator(); ++it) {
             if (it->is_regular_file(ec) && !ec) {
                 out.push_back(it->path());
             }
@@ -146,7 +106,7 @@ CompareResult compare_directories(const std::filesystem::path& lhs, const std::f
     auto normalize = [](const std::filesystem::path& p, const std::filesystem::path& root) {
         std::error_code ec;
         const auto rel = std::filesystem::relative(p, root, ec);
-        return (ec ? p.filename() : rel).string();
+        return (ec ? p.filename() : rel).lexically_normal().string();
     };
     std::sort(left_files.begin(), left_files.end(), [&](const auto& a, const auto& b) {
         return normalize(a, lhs) < normalize(b, lhs);
@@ -180,181 +140,28 @@ CompareResult compare_directories(const std::filesystem::path& lhs, const std::f
 
 } // namespace
 
+namespace api {
+
 int run_replay(const ReplayConfig& cfg) {
-    if (cfg.fast && cfg.speed <= 0.0) {
-        // fast mode ignores speed, allow zero/negative here.
-    } else if (cfg.speed <= 0.0) {
-        util::log(util::LogLevel::Error, "Invalid --speed %.3f; must be > 0 unless --fast is set", cfg.speed);
-        return 1;
-    }
+    replay_engine::ReplayConfig engine_cfg{
+        .wire_inputs = gather_input_files(cfg),
+        .from_ns = cfg.use_time_window ? std::optional<std::uint64_t>(cfg.window_start_ns) : std::nullopt,
+        .to_ns = cfg.use_time_window ? std::optional<std::uint64_t>(cfg.window_end_ns) : std::nullopt,
+        .config_path = {},
+        .output_dir = cfg.output_dir.empty() ? std::filesystem::path("replay_out") : cfg.output_dir,
+        .speed = speed_to_string(cfg),
+        .max_records = cfg.max_records
+    };
 
-    if (cfg.input_files.empty() && cfg.input_directory.empty()) {
-        util::log(util::LogLevel::Error, "No input provided; use --input <dir|file1,file2>");
-        return 1;
-    }
-
-    const bool info_logs = !cfg.quiet;
-
-    persist::WireLogReaderOptions reader_opts;
-    reader_opts.files = cfg.input_files;
-    reader_opts.directory = cfg.input_directory;
-    reader_opts.use_time_window = cfg.use_time_window;
-    reader_opts.window_start_ns = cfg.window_start_ns;
-    reader_opts.window_end_ns = cfg.window_end_ns;
-
-    persist::WireLogReader reader(std::move(reader_opts));
-    if (!reader.open()) {
-        util::log(util::LogLevel::Error, "Failed to open wire log input");
-        return 1;
-    }
-
-    log_if(info_logs, util::LogLevel::Info, "Replay input prepared", nullptr);
-
-    ReplayState state;
-    state.primary_ring = std::make_unique<ExecRing>();
-    state.dropcopy_ring = std::make_unique<ExecRing>();
-    state.divergence_ring = std::make_unique<core::DivergenceRing>();
-    state.gap_ring = std::make_unique<core::SequenceGapRing>();
-    util::Arena arena(util::Arena::default_capacity_bytes);
-    constexpr std::size_t order_capacity_hint = 1u << 16;
-    core::OrderStateStore store(arena, order_capacity_hint);
-
-    core::Reconciler recon(state.stop_flag,
-                           *state.primary_ring,
-                           *state.dropcopy_ring,
-                           store,
-                           state.recon_counters,
-                           *state.divergence_ring,
-                           *state.gap_ring,
-                           &state.audit_counters,
-                           &state.producer_done);
-
-    persist::AuditLogConfig audit_cfg;
-    if (!cfg.output_dir.empty()) {
-        audit_cfg.output_dir = cfg.output_dir;
-    }
-    if (!ensure_output_dir(audit_cfg.output_dir)) {
-        util::log(util::LogLevel::Error, "Failed to create output dir %s", audit_cfg.output_dir.string().c_str());
-        return 1;
-    }
-    persist::AuditLogWriter audit_writer(*state.divergence_ring, *state.gap_ring, state.audit_counters, audit_cfg);
-
-    audit_writer.start();
-    std::thread recon_thread([&] { recon.run(); });
-
-    std::uint64_t last_ts{0};
-    ReplayLoopStats loop_stats{};
-    bool first_record = true;
-
-    core::WireExecEvent wire{};
-    std::uint64_t capture_ts{0};
-    bool success = true;
-
-    constexpr int kMaxPushAttempts = 4096;
-
-    while (true) {
-        auto res = reader.next(wire, capture_ts);
-        if (res.status == persist::WireLogReadStatus::EndOfStream) {
-            break;
-        }
-        if (res.status != persist::WireLogReadStatus::Ok) {
-            switch (res.status) {
-            case persist::WireLogReadStatus::ChecksumMismatch:
-            case persist::WireLogReadStatus::InvalidLength:
-            case persist::WireLogReadStatus::Truncated:
-                ++loop_stats.corrupt_records;
-                util::log(util::LogLevel::Warn, "Skipping corrupt wire record status=%d",
-                          static_cast<int>(res.status));
-                continue;
-            case persist::WireLogReadStatus::IoError:
-                ++loop_stats.read_errors;
-                util::log(util::LogLevel::Error, "Wire log IO error");
-                success = false;
-                break;
-            default:
-                ++loop_stats.read_errors;
-                util::log(util::LogLevel::Error, "Unexpected wire log status=%d", static_cast<int>(res.status));
-                success = false;
-                break;
-            }
-            if (!success) {
-                break;
-            }
-        }
-        if (cfg.max_records > 0 && loop_stats.processed_ok >= cfg.max_records) {
-            ++loop_stats.skipped_due_to_limit;
-            break;
-        }
-
-        const core::Source src = source_from_wire(wire);
-        const core::ExecEvent evt = core::from_wire(wire, src, capture_ts);
-        ExecRing& ring = (src == core::Source::Primary) ? *state.primary_ring : *state.dropcopy_ring;
-
-        bool pushed = false;
-        for (int attempt = 0; attempt < kMaxPushAttempts; ++attempt) {
-            if (ring.try_push(evt)) {
-                pushed = true;
-                break;
-            }
-            if (attempt < 32) {
-                std::this_thread::yield();
-            } else {
-                std::this_thread::sleep_for(std::chrono::microseconds(50));
-            }
-        }
-        if (!pushed) {
-            ++loop_stats.push_failures;
-            util::log(util::LogLevel::Error, "Ring backpressure exceeded while pushing event");
-            success = false;
-            break;
-        }
-
-        if (!cfg.fast) {
-            if (first_record) {
-                first_record = false;
-            } else {
-                std::uint64_t delta = 0;
-                if (capture_ts < last_ts) {
-                    ++loop_stats.backward_timestamps;
-                    util::log(util::LogLevel::Warn,
-                              "Capture timestamp moved backwards prev=%llu curr=%llu",
-                              static_cast<unsigned long long>(last_ts),
-                              static_cast<unsigned long long>(capture_ts));
-                } else {
-                    delta = capture_ts - last_ts;
-                }
-                if (delta > 0 && cfg.speed > 0.0) {
-                    const double scaled = delta / cfg.speed;
-                    const auto sleep_ns = static_cast<std::uint64_t>(scaled);
-                    if (sleep_ns > 0) {
-                        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
-                    }
-                }
-            }
-        }
-
-        last_ts = capture_ts;
-        ++loop_stats.processed_ok;
-        if (cfg.max_records > 0 && loop_stats.processed_ok >= cfg.max_records) {
-            ++loop_stats.skipped_due_to_limit;
-            break;
-        }
-    }
-
-    state.producer_done.store(true, std::memory_order_release);
-    state.stop_flag.store(true, std::memory_order_release);
-
-    if (recon_thread.joinable()) {
-        recon_thread.join();
-    }
-    audit_writer.stop();
-
-    if (!success) {
+    std::string error_msg;
+    const auto res = replay_engine::run_replay(engine_cfg, error_msg);
+    if (res != replay_engine::ReplayResult::Success) {
+        util::log(util::LogLevel::Error, "%s", error_msg.c_str());
         return 1;
     }
 
     if (!cfg.verify_against.empty()) {
-        const auto cmp = compare_directories(audit_cfg.output_dir, cfg.verify_against);
+        const auto cmp = compare_directories(engine_cfg.output_dir, cfg.verify_against);
         if (!cmp.match) {
             util::log(util::LogLevel::Error,
                       "Verification failed against %s: %s",
@@ -365,18 +172,7 @@ int run_replay(const ReplayConfig& cfg) {
     }
 
     if (cfg.verbose && !cfg.quiet) {
-        const auto& stats = reader.stats();
-        util::log(util::LogLevel::Info,
-                  "Replay completed: processed=%zu corrupt=%zu read_errors=%zu push_failures=%zu backward_ts=%zu limit_skips=%zu filtered=%llu files=%llu bytes=%llu",
-                  loop_stats.processed_ok,
-                  loop_stats.corrupt_records,
-                  loop_stats.read_errors,
-                  loop_stats.push_failures,
-                  loop_stats.backward_timestamps,
-                  loop_stats.skipped_due_to_limit,
-                  static_cast<unsigned long long>(stats.filtered_out),
-                  static_cast<unsigned long long>(stats.files_opened),
-                  static_cast<unsigned long long>(stats.bytes_read));
+        util::log(util::LogLevel::Info, "Replay completed");
     }
 
     return 0;

--- a/src/api/replay_engine.cpp
+++ b/src/api/replay_engine.cpp
@@ -1,0 +1,268 @@
+#include "api/replay_engine.hpp"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "core/exec_event.hpp"
+#include "core/order_state_store.hpp"
+#include "core/reconciler.hpp"
+#include "ingest/spsc_ring.hpp"
+#include "persist/audit_log_writer.hpp"
+#include "persist/wire_log_reader.hpp"
+#include "util/arena.hpp"
+#include "util/log.hpp"
+
+namespace replay_engine {
+namespace {
+
+using ExecRing = ingest::SpscRing<core::ExecEvent, 1u << 16>;
+
+struct ReplayLoopStats {
+    std::size_t processed_ok{0};
+    std::size_t read_errors{0};
+    std::size_t corrupt_records{0};
+    std::size_t push_failures{0};
+    std::size_t skipped_due_to_limit{0};
+    std::size_t backward_timestamps{0};
+};
+
+struct ReplayState {
+    std::atomic<bool> stop_flag{false};
+    std::atomic<bool> producer_done{false};
+    std::unique_ptr<ExecRing> primary_ring;
+    std::unique_ptr<ExecRing> dropcopy_ring;
+    std::unique_ptr<core::DivergenceRing> divergence_ring;
+    std::unique_ptr<core::SequenceGapRing> gap_ring;
+    persist::AuditLogCounters audit_counters;
+    core::ReconCounters recon_counters;
+};
+
+core::Source source_from_wire(const core::WireExecEvent& evt) noexcept {
+    return (evt.session_id % 2u == 0) ? core::Source::Primary : core::Source::DropCopy;
+}
+
+bool ensure_output_dir(const std::filesystem::path& p, std::string& err) {
+    std::error_code ec;
+    std::filesystem::create_directories(p, ec);
+    if (ec) {
+        std::ostringstream oss;
+        oss << "failed to create output dir " << p << ": " << ec.message();
+        err = oss.str();
+        return false;
+    }
+    return true;
+}
+
+bool parse_speed(const std::string& speed, double& out_speed, bool& out_fast) {
+    const auto lower = speed;
+    if (lower == "fast" || lower == "max") {
+        out_fast = true;
+        out_speed = 1.0;
+        return true;
+    }
+    if (lower == "realtime") {
+        out_fast = false;
+        out_speed = 1.0;
+        return true;
+    }
+    char* end = nullptr;
+    const double parsed = std::strtod(lower.c_str(), &end);
+    if (!end || *end != '\0') {
+        return false;
+    }
+    out_fast = false;
+    out_speed = parsed;
+    return true;
+}
+
+} // namespace
+
+ReplayResult run_replay(const ReplayConfig& config, std::string& error_msg) {
+    double speed = 1.0;
+    bool fast = false;
+    if (!parse_speed(config.speed.empty() ? "fast" : config.speed, speed, fast)) {
+        error_msg = "invalid speed: " + config.speed;
+        return ReplayResult::ConfigError;
+    }
+    if (!fast && speed <= 0.0) {
+        error_msg = "speed must be > 0 unless fast/max is set";
+        return ReplayResult::ConfigError;
+    }
+
+    if (config.wire_inputs.empty()) {
+        error_msg = "no input provided";
+        return ReplayResult::ConfigError;
+    }
+
+    persist::WireLogReaderOptions reader_opts;
+    reader_opts.files = config.wire_inputs;
+    if (config.from_ns && config.to_ns) {
+        reader_opts.use_time_window = true;
+        reader_opts.window_start_ns = *config.from_ns;
+        reader_opts.window_end_ns = *config.to_ns;
+    }
+
+    persist::WireLogReader reader(std::move(reader_opts));
+    if (!reader.open()) {
+        error_msg = "failed to open wire input";
+        return ReplayResult::WireReadError;
+    }
+
+    ReplayState state;
+    state.primary_ring = std::make_unique<ExecRing>();
+    state.dropcopy_ring = std::make_unique<ExecRing>();
+    state.divergence_ring = std::make_unique<core::DivergenceRing>();
+    state.gap_ring = std::make_unique<core::SequenceGapRing>();
+    util::Arena arena(util::Arena::default_capacity_bytes);
+    constexpr std::size_t order_capacity_hint = 1u << 16;
+    core::OrderStateStore store(arena, order_capacity_hint);
+
+    core::Reconciler recon(state.stop_flag,
+                           *state.primary_ring,
+                           *state.dropcopy_ring,
+                           store,
+                           state.recon_counters,
+                           *state.divergence_ring,
+                           *state.gap_ring,
+                           &state.audit_counters,
+                           &state.producer_done);
+
+    persist::AuditLogConfig audit_cfg;
+    if (!config.output_dir.empty()) {
+        audit_cfg.output_dir = config.output_dir;
+    }
+    if (!ensure_output_dir(audit_cfg.output_dir, error_msg)) {
+        return ReplayResult::OutputError;
+    }
+    persist::AuditLogWriter audit_writer(*state.divergence_ring, *state.gap_ring, state.audit_counters, audit_cfg);
+
+    audit_writer.start();
+    std::thread recon_thread([&] { recon.run(); });
+
+    std::uint64_t last_ts{0};
+    ReplayLoopStats loop_stats{};
+    bool first_record = true;
+
+    core::WireExecEvent wire{};
+    std::uint64_t capture_ts{0};
+    bool success = true;
+
+    constexpr int kMaxPushAttempts = 4096;
+
+    while (true) {
+        auto res = reader.next(wire, capture_ts);
+        if (res.status == persist::WireLogReadStatus::EndOfStream) {
+            break;
+        }
+        if (res.status != persist::WireLogReadStatus::Ok) {
+            switch (res.status) {
+            case persist::WireLogReadStatus::ChecksumMismatch:
+            case persist::WireLogReadStatus::InvalidLength:
+            case persist::WireLogReadStatus::Truncated:
+                ++loop_stats.corrupt_records;
+                util::log(util::LogLevel::Warn, "Skipping corrupt wire record status=%d",
+                          static_cast<int>(res.status));
+                continue;
+            case persist::WireLogReadStatus::IoError:
+                ++loop_stats.read_errors;
+                error_msg = "wire log IO error";
+                success = false;
+                break;
+            default:
+                ++loop_stats.read_errors;
+                error_msg = "unexpected wire log status " + std::to_string(static_cast<int>(res.status));
+                success = false;
+                break;
+            }
+            if (!success) {
+                break;
+            }
+        }
+        if (config.max_records > 0 && loop_stats.processed_ok >= config.max_records) {
+            ++loop_stats.skipped_due_to_limit;
+            break;
+        }
+
+        const core::Source src = source_from_wire(wire);
+        const core::ExecEvent evt = core::from_wire(wire, src, capture_ts);
+        ExecRing& ring = (src == core::Source::Primary) ? *state.primary_ring : *state.dropcopy_ring;
+
+        bool pushed = false;
+        for (int attempt = 0; attempt < kMaxPushAttempts; ++attempt) {
+            if (ring.try_push(evt)) {
+                pushed = true;
+                break;
+            }
+            if (attempt < 32) {
+                std::this_thread::yield();
+            } else {
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            }
+        }
+        if (!pushed) {
+            ++loop_stats.push_failures;
+            error_msg = "ring backpressure exceeded while pushing event";
+            success = false;
+            break;
+        }
+
+        if (!fast) {
+            if (first_record) {
+                first_record = false;
+            } else {
+                std::uint64_t delta = 0;
+                if (capture_ts < last_ts) {
+                    ++loop_stats.backward_timestamps;
+                    util::log(util::LogLevel::Warn,
+                              "Capture timestamp moved backwards prev=%llu curr=%llu",
+                              static_cast<unsigned long long>(last_ts),
+                              static_cast<unsigned long long>(capture_ts));
+                } else {
+                    delta = capture_ts - last_ts;
+                }
+                if (delta > 0 && speed > 0.0) {
+                    const double scaled = delta / speed;
+                    const auto sleep_ns = static_cast<std::uint64_t>(scaled);
+                    if (sleep_ns > 0) {
+                        std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
+                    }
+                }
+            }
+        }
+
+        last_ts = capture_ts;
+        ++loop_stats.processed_ok;
+        if (config.max_records > 0 && loop_stats.processed_ok >= config.max_records) {
+            ++loop_stats.skipped_due_to_limit;
+            break;
+        }
+    }
+
+    state.producer_done.store(true, std::memory_order_release);
+    state.stop_flag.store(true, std::memory_order_release);
+
+    if (recon_thread.joinable()) {
+        recon_thread.join();
+    }
+    audit_writer.stop();
+
+    if (!success) {
+        return ReplayResult::ReconError;
+    }
+
+    return ReplayResult::Success;
+}
+
+} // namespace replay_engine

--- a/src/api/replay_engine.hpp
+++ b/src/api/replay_engine.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace replay_engine {
+
+struct ReplayConfig {
+    std::vector<std::filesystem::path> wire_inputs;
+    std::optional<std::uint64_t> from_ns;
+    std::optional<std::uint64_t> to_ns;
+    std::filesystem::path config_path;
+    std::filesystem::path output_dir;
+    std::string speed;              // "realtime", "fast", "max"
+    std::size_t max_records;        // 0 = unlimited
+};
+
+enum class ReplayResult {
+    Success,
+    WireReadError,
+    ConfigError,
+    ReconError,
+    OutputError
+};
+
+ReplayResult run_replay(const ReplayConfig& config, std::string& error_msg);
+
+} // namespace replay_engine
+

--- a/tests/incident_runner_integration_test.cpp
+++ b/tests/incident_runner_integration_test.cpp
@@ -1,0 +1,262 @@
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <stdexcept>
+#include <vector>
+#include <unistd.h>
+
+#include <gtest/gtest.h>
+
+#include "persist/wire_log_format.hpp"
+
+namespace incident_runner {
+int run_incident_runner_cli(const std::vector<std::string>& args);
+}
+
+namespace {
+
+std::filesystem::path make_temp_dir(const std::string& prefix) {
+    std::string templ = "/tmp/" + prefix + "XXXXXX";
+    std::vector<char> buf(templ.begin(), templ.end());
+    buf.push_back('\0');
+    char* dir = mkdtemp(buf.data());
+    if (!dir) {
+        throw std::runtime_error("mkdtemp failed");
+    }
+    return std::filesystem::path(dir);
+}
+
+bool write_wire_log_with_gap(const std::filesystem::path& path) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        return false;
+    }
+    persist::WireLogHeaderFields header{};
+    std::array<std::byte, persist::wire_log_header_size> header_bytes{};
+    persist::encode_header(header, header_bytes);
+    out.write(reinterpret_cast<const char*>(header_bytes.data()), static_cast<std::streamsize>(header_bytes.size()));
+
+    auto write_record = [&](std::uint64_t seq, std::uint64_t capture_ts) {
+        core::WireExecEvent evt{};
+        evt.seq_num = seq;
+        evt.session_id = 2; // even -> primary
+        evt.price_micro = 1000;
+        evt.qty = 10;
+        evt.cum_qty = 10;
+        evt.sending_time = capture_ts;
+        evt.transact_time = capture_ts;
+        const char exec_id[] = "EXEC";
+        const char order_id[] = "ORDER";
+        const char clord_id[] = "CLORD";
+        std::memcpy(evt.exec_id, exec_id, sizeof(exec_id) - 1);
+        evt.exec_id_len = sizeof(exec_id) - 1;
+        std::memcpy(evt.order_id, order_id, sizeof(order_id) - 1);
+        evt.order_id_len = sizeof(order_id) - 1;
+        std::memcpy(evt.clord_id, clord_id, sizeof(clord_id) - 1);
+        evt.clord_id_len = sizeof(clord_id) - 1;
+
+        std::array<std::byte, persist::wire_exec_event_wire_size> payload{};
+        persist::serialize_wire_exec_event(evt, reinterpret_cast<std::uint8_t*>(payload.data()));
+        persist::RecordFields fields{};
+        persist::encode_record(payload, capture_ts, fields);
+        out.write(reinterpret_cast<const char*>(fields.length_le.data()), sizeof(fields.length_le));
+        out.write(reinterpret_cast<const char*>(fields.capture_ts_le.data()), sizeof(fields.capture_ts_le));
+        out.write(reinterpret_cast<const char*>(payload.data()), static_cast<std::streamsize>(payload.size()));
+        out.write(reinterpret_cast<const char*>(fields.checksum_le.data()), sizeof(fields.checksum_le));
+    };
+
+    write_record(1, 100);
+    write_record(3, 200);
+    return out.good();
+}
+
+void write_incident_spec(const std::filesystem::path& path, const std::string& id, const std::filesystem::path& wire) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.is_open());
+    out << "{\n"
+        << "  \"id\": \"" << id << "\",\n"
+        << "  \"description\": \"integration test\",\n"
+        << "  \"wire_inputs\": [\n"
+        << "    {\"path\": \"" << wire.filename().string() << "\", \"from_ns\": 0, \"to_ns\": 500}\n"
+        << "  ],\n"
+        << "  \"replay\": {\"speed\": \"fast\", \"max_records\": 0}\n"
+        << "}\n";
+}
+
+void write_config(const std::filesystem::path& path, std::size_t max_records) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.is_open());
+    out << "{\n"
+        << "  \"max_records\": " << max_records << "\n"
+        << "}\n";
+}
+
+void write_whitelist_allow_extra(const std::filesystem::path& path) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.is_open());
+    out << "{\n"
+        << "  \"version\": 1,\n"
+        << "  \"rules\": [\n"
+        << "    {\"type\": \"allow_extra_files\", \"patterns\": [\"audit_*\"]},\n"
+        << "    {\"type\": \"ignore_divergence_type\", \"divergence_type\": \"StateMismatch\"},\n"
+        << "    {\"type\": \"ignore_divergence_type\", \"divergence_type\": \"QuantityMismatch\"},\n"
+        << "    {\"type\": \"ignore_divergence_type\", \"divergence_type\": \"TimingAnomaly\"},\n"
+        << "    {\"type\": \"ignore_divergence_type\", \"divergence_type\": \"MissingFill\"},\n"
+        << "    {\"type\": \"ignore_divergence_type\", \"divergence_type\": \"PhantomOrder\"}\n"
+        << "  ]\n"
+        << "}\n";
+}
+
+int run_runner(const std::vector<std::string>& args) {
+    return incident_runner::run_incident_runner_cli(args);
+}
+
+} // namespace
+
+TEST(IncidentRunnerIntegration, FreshGoldenAndMatch) {
+    const auto root = make_temp_dir("incident_runner_");
+    const auto incident_dir = root / "INC-TEST-1";
+    std::filesystem::create_directories(incident_dir);
+    const auto wire = incident_dir / "wire.bin";
+    ASSERT_TRUE(write_wire_log_with_gap(wire));
+
+    write_incident_spec(incident_dir / "incident.json", "INC-TEST-1", wire);
+    write_config(incident_dir / "baseline_config.json", 0);
+    write_config(incident_dir / "candidate_config.json", 0);
+
+    const auto work_dir = root / "work";
+
+    int code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--refresh-golden",
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string()
+    });
+    EXPECT_EQ(code, 0);
+
+    code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string()
+    });
+    EXPECT_EQ(code, 0);
+}
+
+TEST(IncidentRunnerIntegration, MismatchWithoutWhitelist) {
+    const auto root = make_temp_dir("incident_runner_mismatch_");
+    const auto incident_dir = root / "INC-TEST-2";
+    std::filesystem::create_directories(incident_dir);
+    const auto wire = incident_dir / "wire.bin";
+    ASSERT_TRUE(write_wire_log_with_gap(wire));
+
+    write_incident_spec(incident_dir / "incident.json", "INC-TEST-2", wire);
+    write_config(incident_dir / "baseline_config.json", 0);
+    write_config(incident_dir / "candidate_config.json", 1); // limit candidate to suppress gap
+
+    const auto work_dir = root / "work";
+    int code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--refresh-golden",
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string()
+    });
+    ASSERT_EQ(code, 0);
+
+    code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string()
+    });
+    EXPECT_EQ(code, 2);
+}
+
+TEST(IncidentRunnerIntegration, MismatchWhitelisted) {
+    const auto root = make_temp_dir("incident_runner_whitelist_");
+    const auto incident_dir = root / "INC-TEST-3";
+    std::filesystem::create_directories(incident_dir);
+    const auto wire = incident_dir / "wire.bin";
+    ASSERT_TRUE(write_wire_log_with_gap(wire));
+
+    write_incident_spec(incident_dir / "incident.json", "INC-TEST-3", wire);
+    write_config(incident_dir / "baseline_config.json", 1);   // truncate, likely no gaps
+    write_config(incident_dir / "candidate_config.json", 0);  // full, produces gap file
+    write_whitelist_allow_extra(incident_dir / "whitelist.json");
+
+    const auto work_dir = root / "work";
+    int code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--refresh-golden",
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string(),
+        "--whitelist", (incident_dir / "whitelist.json").string()
+    });
+    ASSERT_EQ(code, 0);
+
+    for (const auto& entry : std::filesystem::directory_iterator(work_dir / "golden")) {
+        if (entry.is_regular_file() && entry.path().filename().string().rfind("audit", 0) == 0) {
+            std::filesystem::remove(entry.path());
+        }
+    }
+
+    code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string(),
+        "--whitelist", (incident_dir / "whitelist.json").string()
+    });
+    EXPECT_EQ(code, 0);
+}
+
+TEST(IncidentRunnerIntegration, MissingGoldenIsError) {
+    const auto root = make_temp_dir("incident_runner_missing_");
+    const auto incident_dir = root / "INC-TEST-4";
+    std::filesystem::create_directories(incident_dir);
+    const auto wire = incident_dir / "wire.bin";
+    ASSERT_TRUE(write_wire_log_with_gap(wire));
+
+    write_incident_spec(incident_dir / "incident.json", "INC-TEST-4", wire);
+    write_config(incident_dir / "baseline_config.json", 0);
+    write_config(incident_dir / "candidate_config.json", 0);
+
+    const auto work_dir = root / "work";
+    // Intentionally do not refresh to create golden
+    int code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string()
+    });
+    EXPECT_EQ(code, 3);
+}
+
+TEST(IncidentRunnerIntegration, InvalidSpecFails) {
+    const auto root = make_temp_dir("incident_runner_bad_spec_");
+    const auto incident_dir = root / "INC-TEST-5";
+    std::filesystem::create_directories(incident_dir);
+
+    std::ofstream bad(incident_dir / "incident.json", std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(bad.is_open());
+    bad << "{ invalid json ";
+    bad.close();
+
+    write_config(incident_dir / "baseline_config.json", 0);
+    write_config(incident_dir / "candidate_config.json", 0);
+
+    const auto work_dir = root / "work";
+    int code = run_runner({
+        "--spec", (incident_dir / "incident.json").string(),
+        "--work-dir", work_dir.string(),
+        "--baseline-config", (incident_dir / "baseline_config.json").string(),
+        "--candidate-config", (incident_dir / "candidate_config.json").string()
+    });
+    EXPECT_EQ(code, 3);
+}


### PR DESCRIPTION
## Summary
- add replay_engine library wrapper and refactor replay_main to use it
- introduce fx_incident_runner CLI that refreshes goldens, runs candidates, and reports audit diffs with optional whitelists
- document incident workflow and add integration coverage for the new harness and replay behavior

## Testing
- ctest --test-dir build --output-on-failure

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69497732a48083288a8760fd2a04e8d7)