### PR TITLE
Add Aeron end-to-end reconciler tests and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,25 @@ jobs:
       - name: Cleanup
         if: always()
         run: docker compose down --volumes --remove-orphans
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker images
+        run: docker compose build
+
+      - name: Run Aeron E2E tests
+        run: docker compose run --rm unit-tests ctest --preset release --output-on-failure -L e2e
+
+      - name: Cleanup
+        if: always()
+        run: docker compose down --volumes --remove-orphans

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,5 +219,20 @@ gtest_discover_tests(integration_aeron_flow
   DISCOVERY_MODE PRE_TEST
 )
 
+add_executable(fx_e2e_tests
+    tests/e2e/aeron_test_harness.cpp
+    tests/e2e/e2e_aeron_reconciler_tests.cpp
+    src/ingest/aeron_subscriber.cpp
+    src/core/reconciler.cpp
+)
+target_include_directories(fx_e2e_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+target_link_libraries(fx_e2e_tests PRIVATE fx_core aeron::aeron_client GTest::gtest_main)
+
+gtest_discover_tests(fx_e2e_tests
+  TEST_PREFIX e2e_
+  DISCOVERY_MODE PRE_TEST
+  PROPERTIES LABELS "e2e"
+)
+
 add_executable(benchmarks bench/bench_main.cpp src/ingest/fix_parser.cpp src/core/reconciler.cpp)
 target_link_libraries(benchmarks PRIVATE fx_core)

--- a/src/ingest/spsc_ring.hpp
+++ b/src/ingest/spsc_ring.hpp
@@ -15,6 +15,8 @@ class alignas(64) SpscRing {
                   "Capacity must be power of two");
 
 public:
+    using value_type = T;
+
     SpscRing() : head_(0), tail_(0) {}
 
     bool try_push(const T& v) noexcept {

--- a/tests/e2e/aeron_test_harness.cpp
+++ b/tests/e2e/aeron_test_harness.cpp
@@ -1,0 +1,229 @@
+#include "tests/e2e/aeron_test_harness.hpp"
+
+#include <array>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <sstream>
+#include <system_error>
+#include <utility>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <processthreadsapi.h>
+#else
+#include <csignal>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#include <concurrent/AtomicBuffer.h>
+
+namespace e2e {
+
+namespace {
+using Clock = std::chrono::steady_clock;
+}
+
+MediaDriverGuard::MediaDriverGuard(long pid, std::filesystem::path dir) noexcept
+    : pid_(pid), aeron_dir_(std::move(dir)) {}
+
+MediaDriverGuard::MediaDriverGuard(MediaDriverGuard&& other) noexcept
+    : pid_(other.pid_), aeron_dir_(std::move(other.aeron_dir_)) {
+    other.pid_ = -1;
+}
+
+MediaDriverGuard& MediaDriverGuard::operator=(MediaDriverGuard&& other) noexcept {
+    if (this != &other) {
+        stop();
+        pid_ = other.pid_;
+        aeron_dir_ = std::move(other.aeron_dir_);
+        other.pid_ = -1;
+    }
+    return *this;
+}
+
+MediaDriverGuard::~MediaDriverGuard() { stop(); }
+
+bool MediaDriverGuard::valid() const noexcept {
+    return pid_ > 0;
+}
+
+void MediaDriverGuard::stop() noexcept {
+#ifdef _WIN32
+    if (pid_ > 0) {
+        HANDLE process = reinterpret_cast<HANDLE>(static_cast<uintptr_t>(pid_));
+        TerminateProcess(process, 0);
+        WaitForSingleObject(process, 5000);
+        CloseHandle(process);
+        pid_ = -1;
+    }
+#else
+    if (pid_ > 0) {
+        kill(pid_, SIGTERM);
+        int status = 0;
+        waitpid(pid_, &status, 0);
+        pid_ = -1;
+    }
+#endif
+
+    if (!aeron_dir_.empty()) {
+        std::error_code ec;
+        std::filesystem::remove_all(aeron_dir_, ec);
+    }
+}
+
+MediaDriverGuard MediaDriverGuard::start(const std::filesystem::path& aeron_dir,
+                                         chrono::milliseconds ready_timeout,
+                                         std::string& error_out) noexcept {
+    error_out.clear();
+#ifdef _WIN32
+    // Windows Aeron media driver is not spawned here; tests should skip.
+    error_out = "External Aeron media driver launch is not supported on Windows in this harness.";
+    return MediaDriverGuard{};
+#else
+    pid_t pid = fork();
+    if (pid == 0) {
+        const std::string dir_arg = "-Daeron.dir=" + aeron_dir.string();
+        const char* argv[] = {"aeronmd",
+                              dir_arg.c_str(),
+                              "-Daeron.socket.soReusePort=true",
+                              nullptr};
+        execvp("aeronmd", const_cast<char* const*>(argv));
+        std::cerr << "Failed to exec aeronmd" << std::endl;
+        std::_Exit(127);
+    }
+    if (pid < 0) {
+        error_out = "fork() failed launching aeronmd";
+        return MediaDriverGuard{};
+    }
+
+    if (!wait_for_driver_ready(aeron_dir, ready_timeout)) {
+        error_out = "aeronmd did not create cnc.dat in time";
+        // Ensure the process is reaped to avoid zombies.
+        MediaDriverGuard guard(pid, aeron_dir);
+        guard.stop();
+        return MediaDriverGuard{};
+    }
+
+    return MediaDriverGuard(pid, aeron_dir);
+#endif
+}
+
+std::filesystem::path make_unique_aeron_dir(const std::string& test_name) {
+    const auto now = Clock::now().time_since_epoch().count();
+    std::ostringstream oss;
+#ifdef _WIN32
+    const auto pid = static_cast<unsigned long>(GetCurrentProcessId());
+#else
+    const auto pid = static_cast<unsigned long>(::getpid());
+#endif
+    oss << "aeron-e2e-" << test_name << "-" << now << "-" << pid;
+    const auto dir = std::filesystem::temp_directory_path() / oss.str();
+    std::filesystem::create_directories(dir);
+    return dir;
+}
+
+bool wait_for_driver_ready(const std::filesystem::path& aeron_dir,
+                           chrono::milliseconds timeout) noexcept {
+    const auto cnc_path = aeron_dir / "cnc.dat";
+    const auto deadline = Clock::now() + timeout;
+    while (Clock::now() < deadline) {
+        if (std::filesystem::exists(cnc_path)) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    }
+    return std::filesystem::exists(cnc_path);
+}
+
+std::shared_ptr<aeron::Aeron> connect_client(const std::filesystem::path& aeron_dir,
+                                             std::string& error_out) noexcept {
+    aeron::Context ctx;
+    ctx.aeronDir(aeron_dir.string());
+    try {
+        return aeron::Aeron::connect(ctx);
+    } catch (const std::exception& ex) {
+        error_out = ex.what();
+        return nullptr;
+    }
+}
+
+std::shared_ptr<aeron::Publication> make_publication(aeron::Aeron& client,
+                                                     const std::string& channel,
+                                                     std::int32_t stream_id,
+                                                     Clock::time_point deadline) noexcept {
+    const auto reg_id = client.addPublication(channel, stream_id);
+    while (Clock::now() < deadline) {
+        auto pub = client.findPublication(reg_id);
+        if (pub) {
+            return pub;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
+    return nullptr;
+}
+
+std::size_t publish_events(aeron::Aeron& client,
+                           const std::string& channel,
+                           std::int32_t stream_id,
+                           const std::vector<core::WireExecEvent>& events,
+                           Clock::time_point deadline) noexcept {
+    auto pub = make_publication(client, channel, stream_id, deadline);
+    if (!pub) {
+        return 0;
+    }
+
+    std::size_t sent = 0;
+    std::array<std::uint8_t, sizeof(core::WireExecEvent)> buffer{};
+    while (sent < events.size() && Clock::now() < deadline) {
+        std::memcpy(buffer.data(), &events[sent], sizeof(core::WireExecEvent));
+        aeron::concurrent::AtomicBuffer atomic_buffer(buffer.data(), buffer.size());
+        const auto res = pub->offer(atomic_buffer, 0, static_cast<aeron::util::index_t>(buffer.size()));
+        if (res > 0) {
+            ++sent;
+        } else {
+            std::this_thread::yield();
+        }
+    }
+    return sent;
+}
+
+void fill_id(char (&dest)[core::WireExecEvent::id_capacity],
+             const std::string& src,
+             std::uint8_t& len_out) noexcept {
+    const auto len = src.size() > core::WireExecEvent::id_capacity ? core::WireExecEvent::id_capacity : src.size();
+    std::memcpy(dest, src.data(), len);
+    len_out = static_cast<std::uint8_t>(len);
+}
+
+core::WireExecEvent make_wire_exec(std::uint64_t seq,
+                                   std::uint16_t session,
+                                   std::uint8_t exec_type,
+                                   std::uint8_t ord_status,
+                                   std::int64_t price_micro,
+                                   std::int64_t qty,
+                                   std::int64_t cum_qty,
+                                   std::uint64_t sending_time,
+                                   std::uint64_t transact_time,
+                                   const std::string& clord_id,
+                                   const std::string& order_id,
+                                   const std::string& exec_id) noexcept {
+    core::WireExecEvent evt{};
+    evt.exec_type = exec_type;
+    evt.ord_status = ord_status;
+    evt.seq_num = seq;
+    evt.session_id = session;
+    evt.price_micro = price_micro;
+    evt.qty = qty;
+    evt.cum_qty = cum_qty;
+    evt.sending_time = sending_time;
+    evt.transact_time = transact_time;
+    fill_id(evt.exec_id, exec_id, evt.exec_id_len);
+    fill_id(evt.order_id, order_id, evt.order_id_len);
+    fill_id(evt.clord_id, clord_id, evt.clord_id_len);
+    return evt;
+}
+
+} // namespace e2e

--- a/tests/e2e/aeron_test_harness.hpp
+++ b/tests/e2e/aeron_test_harness.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <Aeron.h>
+
+#include "core/wire_exec_event.hpp"
+
+namespace e2e {
+
+namespace chrono = std::chrono;
+
+// RAII guard for an external Aeron media driver process.
+class MediaDriverGuard {
+public:
+    MediaDriverGuard() = default;
+    MediaDriverGuard(const MediaDriverGuard&) = delete;
+    MediaDriverGuard& operator=(const MediaDriverGuard&) = delete;
+    MediaDriverGuard(MediaDriverGuard&& other) noexcept;
+    MediaDriverGuard& operator=(MediaDriverGuard&& other) noexcept;
+    ~MediaDriverGuard();
+
+    bool valid() const noexcept;
+    void stop() noexcept;
+
+    static MediaDriverGuard start(const std::filesystem::path& aeron_dir,
+                                  chrono::milliseconds ready_timeout,
+                                  std::string& error_out) noexcept;
+
+private:
+    explicit MediaDriverGuard(long pid, std::filesystem::path dir) noexcept;
+
+    long pid_{-1};
+    std::filesystem::path aeron_dir_{};
+};
+
+// Creates a unique Aeron directory for a single test run.
+std::filesystem::path make_unique_aeron_dir(const std::string& test_name);
+
+// Waits for cnc.dat to appear, signalling the media driver is ready.
+bool wait_for_driver_ready(const std::filesystem::path& aeron_dir,
+                           chrono::milliseconds timeout) noexcept;
+
+// Connects an Aeron client pointed at the provided directory.
+std::shared_ptr<aeron::Aeron> connect_client(const std::filesystem::path& aeron_dir,
+                                             std::string& error_out) noexcept;
+
+// Creates a publication with bounded polling. Returns nullptr on failure.
+std::shared_ptr<aeron::Publication> make_publication(aeron::Aeron& client,
+                                                     const std::string& channel,
+                                                     std::int32_t stream_id,
+                                                     chrono::steady_clock::time_point deadline) noexcept;
+
+// Publishes all wire events in order before the deadline. Returns the number of fragments sent.
+std::size_t publish_events(aeron::Aeron& client,
+                           const std::string& channel,
+                           std::int32_t stream_id,
+                           const std::vector<core::WireExecEvent>& events,
+                           chrono::steady_clock::time_point deadline) noexcept;
+
+// Helper to copy string data into a WireExecEvent field while setting length safely.
+void fill_id(char (&dest)[core::WireExecEvent::id_capacity],
+             const std::string& src,
+             std::uint8_t& len_out) noexcept;
+
+// Utility to build a WireExecEvent with explicit fields for deterministic tests.
+core::WireExecEvent make_wire_exec(std::uint64_t seq,
+                                   std::uint16_t session,
+                                   std::uint8_t exec_type,
+                                   std::uint8_t ord_status,
+                                   std::int64_t price_micro,
+                                   std::int64_t qty,
+                                   std::int64_t cum_qty,
+                                   std::uint64_t sending_time,
+                                   std::uint64_t transact_time,
+                                   const std::string& clord_id,
+                                   const std::string& order_id,
+                                   const std::string& exec_id) noexcept;
+
+// Generic ring drain helper for SPSC rings used in tests.
+template <typename T, typename Ring>
+std::vector<T> drain_ring(Ring& ring) {
+    std::vector<T> out;
+    T item{};
+    while (ring.try_pop(item)) {
+        out.push_back(item);
+    }
+    return out;
+}
+
+} // namespace e2e

--- a/tests/e2e/e2e_aeron_reconciler_tests.cpp
+++ b/tests/e2e/e2e_aeron_reconciler_tests.cpp
@@ -1,0 +1,394 @@
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "core/divergence.hpp"
+#include "core/order_state_store.hpp"
+#include "core/reconciler.hpp"
+#include "core/sequence_tracker.hpp"
+#include "ingest/aeron_subscriber.hpp"
+#include "tests/e2e/aeron_test_harness.hpp"
+#include "util/arena.hpp"
+
+using namespace std::chrono_literals;
+
+namespace {
+
+struct TestEnv {
+    std::filesystem::path aeron_dir;
+    e2e::MediaDriverGuard driver;
+    std::shared_ptr<aeron::Aeron> aeron_client;
+    std::unique_ptr<ingest::Ring> primary_ring;
+    std::unique_ptr<ingest::Ring> dropcopy_ring;
+    ingest::ThreadStats primary_stats{};
+    ingest::ThreadStats dropcopy_stats{};
+    core::ReconCounters counters{};
+    core::DivergenceRing divergence_ring;
+    core::SequenceGapRing seq_gap_ring;
+    std::atomic<bool> stop_flag{false};
+    util::Arena arena{util::Arena::default_capacity_bytes};
+    core::OrderStateStore store{arena, 1u << 12};
+
+    std::thread primary_thread;
+    std::thread dropcopy_thread;
+    std::thread recon_thread;
+    std::shared_ptr<aeron::Aeron> publisher_client;
+    std::shared_ptr<ingest::AeronSubscriber> primary_sub;
+    std::shared_ptr<ingest::AeronSubscriber> dropcopy_sub;
+    std::shared_ptr<core::Reconciler> reconciler;
+
+    ~TestEnv() {
+        teardown();
+    }
+
+    void teardown() {
+        stop_flag.store(true, std::memory_order_release);
+        if (primary_thread.joinable()) primary_thread.join();
+        if (dropcopy_thread.joinable()) dropcopy_thread.join();
+        if (recon_thread.joinable()) recon_thread.join();
+        driver.stop();
+    }
+};
+
+struct WaitOutcome {
+    bool success{false};
+    std::string message;
+};
+
+WaitOutcome wait_for_counts(const core::ReconCounters& counters,
+                            std::uint64_t expected_primary,
+                            std::uint64_t expected_dropcopy,
+                            std::uint64_t expected_divergences,
+                            std::uint64_t expected_gaps,
+                            std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (counters.internal_events >= expected_primary &&
+            counters.dropcopy_events >= expected_dropcopy &&
+            counters.divergence_total >= expected_divergences &&
+            (counters.primary_seq_gaps + counters.dropcopy_seq_gaps +
+             counters.primary_seq_duplicates + counters.dropcopy_seq_duplicates +
+             counters.primary_seq_out_of_order + counters.dropcopy_seq_out_of_order) >= expected_gaps) {
+            return {true, ""};
+        }
+        std::this_thread::sleep_for(10ms);
+    }
+
+    std::ostringstream oss;
+    oss << "Timed out waiting for counters. "
+        << "primary=" << counters.internal_events << "/" << expected_primary << " "
+        << "dropcopy=" << counters.dropcopy_events << "/" << expected_dropcopy << " "
+        << "divergence_total=" << counters.divergence_total << "/" << expected_divergences << " "
+        << "gap_counts=" << (counters.primary_seq_gaps + counters.dropcopy_seq_gaps +
+                             counters.primary_seq_duplicates + counters.dropcopy_seq_duplicates +
+                             counters.primary_seq_out_of_order + counters.dropcopy_seq_out_of_order)
+        << "/" << expected_gaps << " "
+        << "divergence_ring_drops=" << counters.divergence_ring_drops << " "
+        << "seq_gap_ring_drops=" << counters.sequence_gap_ring_drops;
+    return {false, oss.str()};
+}
+
+std::unique_ptr<TestEnv> make_env(const std::string& test_name) {
+    auto env = std::make_unique<TestEnv>();
+    env->primary_ring = std::make_unique<ingest::Ring>();
+    env->dropcopy_ring = std::make_unique<ingest::Ring>();
+
+    env->aeron_dir = e2e::make_unique_aeron_dir(test_name);
+    std::string err;
+    env->driver = e2e::MediaDriverGuard::start(env->aeron_dir, 5s, err);
+    if (!env->driver.valid()) {
+        ADD_FAILURE() << "Failed to start Aeron media driver: " << err;
+        return env;
+    }
+
+    env->aeron_client = e2e::connect_client(env->aeron_dir, err);
+    if (!env->aeron_client) {
+        ADD_FAILURE() << "Failed to connect Aeron client: " << err;
+        return env;
+    }
+    env->publisher_client = e2e::connect_client(env->aeron_dir, err);
+    if (!env->publisher_client) {
+        ADD_FAILURE() << "Failed to connect publisher client: " << err;
+        return env;
+    }
+
+    return env;
+}
+
+void start_threads(TestEnv& env,
+                   const std::string& primary_channel,
+                   std::int32_t primary_stream,
+                   const std::string& dropcopy_channel,
+                   std::int32_t dropcopy_stream) {
+    env.primary_sub = std::make_shared<ingest::AeronSubscriber>(primary_channel,
+                                                                primary_stream,
+                                                                *env.primary_ring,
+                                                                env.primary_stats,
+                                                                core::Source::Primary,
+                                                                env.aeron_client,
+                                                                env.stop_flag);
+    env.dropcopy_sub = std::make_shared<ingest::AeronSubscriber>(dropcopy_channel,
+                                                                 dropcopy_stream,
+                                                                 *env.dropcopy_ring,
+                                                                 env.dropcopy_stats,
+                                                                 core::Source::DropCopy,
+                                                                 env.aeron_client,
+                                                                 env.stop_flag);
+
+    env.reconciler = std::make_shared<core::Reconciler>(env.stop_flag,
+                                                        *env.primary_ring,
+                                                        *env.dropcopy_ring,
+                                                        env.store,
+                                                        env.counters,
+                                                        env.divergence_ring,
+                                                        env.seq_gap_ring);
+
+    env.primary_thread = std::thread([sub = env.primary_sub] { sub->run(); });
+    env.dropcopy_thread = std::thread([sub = env.dropcopy_sub] { sub->run(); });
+    env.recon_thread = std::thread([recon = env.reconciler] { recon->run(); });
+}
+
+TEST(E2EReconciler, HappyPathNoDivergenceNoGaps) {
+#ifdef _WIN32
+    GTEST_SKIP() << "Aeron media driver process launching is not supported in this harness on Windows.";
+#endif
+    constexpr std::int32_t primary_stream = 31001;
+    constexpr std::int32_t dropcopy_stream = 31002;
+    const std::string primary_channel = "aeron:udp?endpoint=localhost:31021";
+    const std::string dropcopy_channel = "aeron:udp?endpoint=localhost:31022";
+    constexpr std::uint16_t session_id = 42;
+    constexpr std::size_t n = 6;
+
+    auto env = make_env("happy");
+    ASSERT_TRUE(env->driver.valid());
+    ASSERT_NE(env->aeron_client, nullptr);
+    ASSERT_NE(env->publisher_client, nullptr);
+
+    start_threads(*env, primary_channel, primary_stream, dropcopy_channel, dropcopy_stream);
+
+    std::vector<core::WireExecEvent> primary_msgs;
+    std::vector<core::WireExecEvent> dropcopy_msgs;
+    primary_msgs.reserve(n);
+    dropcopy_msgs.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto seq = static_cast<std::uint64_t>(i + 1);
+        const std::string clord = "CID-HAPPY-" + std::to_string(seq);
+        const std::string oid = "OID-HAPPY-" + std::to_string(seq);
+        primary_msgs.push_back(e2e::make_wire_exec(seq,
+                                                   session_id,
+                                                   static_cast<std::uint8_t>(core::ExecType::Fill),
+                                                   static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                                   1'000'000 + static_cast<std::int64_t>(seq),
+                                                   100 + static_cast<std::int64_t>(seq),
+                                                   100 + static_cast<std::int64_t>(seq),
+                                                   1000 + seq,
+                                                   1000 + seq,
+                                                   clord,
+                                                   oid,
+                                                   "EXEC-HAPPY-P-" + std::to_string(seq)));
+        dropcopy_msgs.push_back(e2e::make_wire_exec(seq,
+                                                    session_id,
+                                                    static_cast<std::uint8_t>(core::ExecType::Fill),
+                                                    static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                                    1'000'000 + static_cast<std::int64_t>(seq),
+                                                    100 + static_cast<std::int64_t>(seq),
+                                                    100 + static_cast<std::int64_t>(seq),
+                                                    1000 + seq,
+                                                    1000 + seq,
+                                                    clord,
+                                                    oid,
+                                                    "EXEC-HAPPY-D-" + std::to_string(seq)));
+    }
+
+    const auto deadline = std::chrono::steady_clock::now() + 8s;
+    const auto sent_primary = e2e::publish_events(*env->publisher_client,
+                                                  primary_channel,
+                                                  primary_stream,
+                                                  primary_msgs,
+                                                  deadline);
+    const auto sent_dropcopy = e2e::publish_events(*env->publisher_client,
+                                                   dropcopy_channel,
+                                                   dropcopy_stream,
+                                                   dropcopy_msgs,
+                                                   deadline);
+    ASSERT_EQ(sent_primary, n) << "Failed to publish all primary messages";
+    ASSERT_EQ(sent_dropcopy, n) << "Failed to publish all dropcopy messages";
+
+    const auto outcome = wait_for_counts(env->counters,
+                                         n,
+                                         n,
+                                         0,
+                                         0,
+                                         5s);
+    if (!outcome.success) {
+        auto divs = e2e::drain_ring<core::Divergence>(env->divergence_ring);
+        auto gaps = e2e::drain_ring<core::SequenceGapEvent>(env->seq_gap_ring);
+        FAIL() << outcome.message << " divergences=" << divs.size() << " gaps=" << gaps.size();
+    }
+
+    EXPECT_EQ(env->counters.internal_events, n);
+    EXPECT_EQ(env->counters.dropcopy_events, n);
+    EXPECT_EQ(env->counters.divergence_total, 0);
+    EXPECT_EQ(env->counters.primary_seq_gaps + env->counters.dropcopy_seq_gaps, 0);
+}
+
+TEST(E2EReconciler, DivergenceAndGapClassification) {
+#ifdef _WIN32
+    GTEST_SKIP() << "Aeron media driver process launching is not supported in this harness on Windows.";
+#endif
+    constexpr std::int32_t primary_stream = 32001;
+    constexpr std::int32_t dropcopy_stream = 32002;
+    const std::string primary_channel = "aeron:udp?endpoint=localhost:32021";
+    const std::string dropcopy_channel = "aeron:udp?endpoint=localhost:32022";
+    constexpr std::uint16_t session_id = 84;
+
+    auto env = make_env("divergence");
+    ASSERT_TRUE(env->driver.valid());
+    ASSERT_NE(env->aeron_client, nullptr);
+    ASSERT_NE(env->publisher_client, nullptr);
+
+    start_threads(*env, primary_channel, primary_stream, dropcopy_channel, dropcopy_stream);
+
+    // Scenarios:
+    // 1) MissingFill: dropcopy reports fill seq 2, primary only new.
+    // 2) PhantomOrder: dropcopy order never seen on primary.
+    // 3) QuantityMismatch: differing cum qty.
+    // 4) StateMismatch: statuses differ.
+    // Also inject sequence gaps/out-of-order.
+    std::vector<core::WireExecEvent> primary_msgs;
+    std::vector<core::WireExecEvent> dropcopy_msgs;
+
+    // Primary order A: New seq 1, gap (skip 2), Fill seq 3 (after gap) -> gap on primary.
+    primary_msgs.push_back(e2e::make_wire_exec(1, session_id,
+                                               static_cast<std::uint8_t>(core::ExecType::New),
+                                               static_cast<std::uint8_t>(core::OrdStatus::New),
+                                               1'000'000, 0, 0, 1000, 1000,
+                                               "CL-A", "OID-A", "EXEC-A-1"));
+    primary_msgs.push_back(e2e::make_wire_exec(3, session_id,
+                                               static_cast<std::uint8_t>(core::ExecType::Fill),
+                                               static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                               1'000'000, 100, 100, 1001, 1001,
+                                               "CL-A", "OID-A", "EXEC-A-3"));
+
+    // Primary order B: New seq 4, quantity mismatch vs dropcopy.
+    primary_msgs.push_back(e2e::make_wire_exec(4, session_id,
+                                               static_cast<std::uint8_t>(core::ExecType::New),
+                                               static_cast<std::uint8_t>(core::OrdStatus::New),
+                                               1'100'000, 0, 0, 2000, 2000,
+                                               "CL-B", "OID-B", "EXEC-B-4"));
+    primary_msgs.push_back(e2e::make_wire_exec(5, session_id,
+                                               static_cast<std::uint8_t>(core::ExecType::Fill),
+                                               static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                               1'100'000, 50, 50, 2001, 2001,
+                                               "CL-B", "OID-B", "EXEC-B-5"));
+
+    // Dropcopy order A: Partial seq 1 (duplicate intentional), Fill seq 2 (missing fill divergence).
+    dropcopy_msgs.push_back(e2e::make_wire_exec(1, session_id,
+                                                static_cast<std::uint8_t>(core::ExecType::PartialFill),
+                                                static_cast<std::uint8_t>(core::OrdStatus::PartiallyFilled),
+                                                1'000'000, 50, 50, 1000, 1000,
+                                                "CL-A", "OID-A", "EXEC-A-DC-1"));
+    dropcopy_msgs.push_back(e2e::make_wire_exec(2, session_id,
+                                                static_cast<std::uint8_t>(core::ExecType::Fill),
+                                                static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                                1'000'000, 50, 100, 1001, 1001,
+                                                "CL-A", "OID-A", "EXEC-A-DC-2"));
+
+    // Dropcopy order B: Fill seq 3 with cum 80 -> quantity mismatch vs 50.
+    dropcopy_msgs.push_back(e2e::make_wire_exec(3, session_id,
+                                                static_cast<std::uint8_t>(core::ExecType::Fill),
+                                                static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                                1'100'000, 80, 80, 2001, 2001,
+                                                "CL-B", "OID-B", "EXEC-B-DC-3"));
+
+    // Dropcopy order C: Phantom order seq 4.
+    dropcopy_msgs.push_back(e2e::make_wire_exec(4, session_id,
+                                                static_cast<std::uint8_t>(core::ExecType::New),
+                                                static_cast<std::uint8_t>(core::OrdStatus::New),
+                                                1'200'000, 0, 0, 3000, 3000,
+                                                "CL-C", "OID-C", "EXEC-C-DC-4"));
+
+    // Dropcopy order D: State mismatch (dropcopy Canceled, primary New never canceled).
+    primary_msgs.push_back(e2e::make_wire_exec(6, session_id,
+                                               static_cast<std::uint8_t>(core::ExecType::New),
+                                               static_cast<std::uint8_t>(core::OrdStatus::New),
+                                               1'300'000, 0, 0, 4000, 4000,
+                                               "CL-D", "OID-D", "EXEC-D-6"));
+    dropcopy_msgs.push_back(e2e::make_wire_exec(5, session_id,
+                                                static_cast<std::uint8_t>(core::ExecType::Cancel),
+                                                static_cast<std::uint8_t>(core::OrdStatus::Canceled),
+                                                1'300'000, 0, 0, 4000, 4000,
+                                                "CL-D", "OID-D", "EXEC-D-DC-5"));
+
+    // Out-of-order duplicate on dropcopy for order A (seq 2 again) to trigger duplicate/out-of-order.
+    dropcopy_msgs.push_back(e2e::make_wire_exec(2, session_id,
+                                                static_cast<std::uint8_t>(core::ExecType::Fill),
+                                                static_cast<std::uint8_t>(core::OrdStatus::Filled),
+                                                1'000'000, 50, 100, 1002, 1002,
+                                                "CL-A", "OID-A", "EXEC-A-DC-2B"));
+
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    const auto sent_primary = e2e::publish_events(*env->publisher_client,
+                                                  primary_channel,
+                                                  primary_stream,
+                                                  primary_msgs,
+                                                  deadline);
+    const auto sent_dropcopy = e2e::publish_events(*env->publisher_client,
+                                                   dropcopy_channel,
+                                                   dropcopy_stream,
+                                                   dropcopy_msgs,
+                                                   deadline);
+
+    ASSERT_EQ(sent_primary, primary_msgs.size()) << "Published fewer primary messages";
+    ASSERT_EQ(sent_dropcopy, dropcopy_msgs.size()) << "Published fewer dropcopy messages";
+
+    // Expected divergences: MissingFill (A), PhantomOrder (C), QuantityMismatch (B), StateMismatch (D).
+    const auto expected_divergences = 4u;
+    const auto expected_gaps = 2u; // primary gap (seq jump) + dropcopy duplicate/out-of-order
+    const auto outcome = wait_for_counts(env->counters,
+                                         sent_primary,
+                                         sent_dropcopy,
+                                         expected_divergences,
+                                         expected_gaps,
+                                         8s);
+    if (!outcome.success) {
+        auto divs = e2e::drain_ring<core::Divergence>(env->divergence_ring);
+        auto gaps = e2e::drain_ring<core::SequenceGapEvent>(env->seq_gap_ring);
+        FAIL() << outcome.message << " divergences=" << divs.size() << " gaps=" << gaps.size();
+    }
+
+    auto divergences = e2e::drain_ring<core::Divergence>(env->divergence_ring);
+    ASSERT_EQ(divergences.size(), expected_divergences);
+
+    std::size_t missing_fill = 0, phantom = 0, qty_mismatch = 0, state_mismatch = 0;
+    for (const auto& d : divergences) {
+        switch (d.type) {
+        case core::DivergenceType::MissingFill: ++missing_fill; break;
+        case core::DivergenceType::PhantomOrder: ++phantom; break;
+        case core::DivergenceType::QuantityMismatch: ++qty_mismatch; break;
+        case core::DivergenceType::StateMismatch: ++state_mismatch; break;
+        default: break;
+        }
+    }
+    EXPECT_EQ(missing_fill, 1u);
+    EXPECT_EQ(phantom, 1u);
+    EXPECT_EQ(qty_mismatch, 1u);
+    EXPECT_EQ(state_mismatch, 1u);
+
+    auto gaps = e2e::drain_ring<core::SequenceGapEvent>(env->seq_gap_ring);
+    EXPECT_GE(gaps.size(), 1u);
+    EXPECT_GE(env->counters.primary_seq_gaps + env->counters.dropcopy_seq_gaps +
+                  env->counters.primary_seq_duplicates + env->counters.dropcopy_seq_duplicates +
+                  env->counters.primary_seq_out_of_order + env->counters.dropcopy_seq_out_of_order,
+              expected_gaps);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- add an Aeron E2E test harness that launches the media driver, publishes WireExecEvent payloads, and drains through the real subscriber + reconciler pipeline
- introduce deterministic E2E gtests covering happy-path ingestion and divergence/gap classification, plus CMake target fx_e2e_tests with e2e label
- wire an e2e GitHub Actions job and expose ring value_type for cleaner test draining

## Testing
- `cmake --preset release` *(fails: Aeron client library not present in the local environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499e6f97a48328afb4ccb99f711d96)